### PR TITLE
Column skipping feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 target
 *.iml
 .okhttpcache
+
+\.classpath
+
+\.project
+
+\.settings/org\.eclipse\.core\.resources\.prefs
+
+\.settings/org\.eclipse\.jdt\.core\.prefs
+
+\.settings/org\.eclipse\.m2e\.core\.prefs

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnectorConfig.java
@@ -46,6 +46,7 @@ class SpoolDirCsvSourceConnectorConfig extends SpoolDirSourceConnectorConfig {
   public static final String CSV_NULL_FIELD_INDICATOR_CONF = "csv.null.field.indicator";
   public static final String CSV_FIRST_ROW_AS_HEADER_CONF = "csv.first.row.as.header";
   public static final String CSV_CHARSET_CONF = "csv.file.charset";
+  public static final String CSV_IGNORED_COLUMNS_CONF = "csv.ignored.columns";
 
   public static final String CSV_CASE_SENSITIVE_FIELD_NAMES_CONF = "csv.case.sensitive.field.names";
   static final String CSV_SKIP_LINES_DOC = "Number of lines to skip in the beginning of the file.";
@@ -75,6 +76,8 @@ class SpoolDirCsvSourceConnectorConfig extends SpoolDirSourceConnectorConfig {
   static final boolean CSV_FIRST_ROW_AS_HEADER_DEFAULT = false;
   static final String CSV_CHARSET_DOC = "Character set to read wth file with.";
   static final String CSV_CHARSET_DEFAULT = Charset.defaultCharset().name();
+  static final String CSV_IGNORED_COLUMNS_DOC = "Comma separated list of columns to ignore during processing.";
+  static final String CSV_IGNORED_COLUMNS_DEFAULT = "";
 
   static final String CSV_CASE_SENSITIVE_FIELD_NAMES_DOC = "Flag to determine if the field names in the header row should be treated as case sensitive.";
   static final String CSV_GROUP = "csv";
@@ -93,6 +96,7 @@ class SpoolDirCsvSourceConnectorConfig extends SpoolDirSourceConnectorConfig {
   public final boolean firstRowAsHeader;
   public final Charset charset;
   public final boolean caseSensitiveFieldNames;
+  public final String ignoredColumns;
 
   public SpoolDirCsvSourceConnectorConfig(final boolean isTask, Map<String, ?> settings) {
     super(isTask, conf(), settings);
@@ -112,6 +116,7 @@ class SpoolDirCsvSourceConnectorConfig extends SpoolDirSourceConnectorConfig {
     this.charset = Charset.forName(charsetName);
 
     this.caseSensitiveFieldNames = this.getBoolean(SpoolDirCsvSourceConnectorConfig.CSV_CASE_SENSITIVE_FIELD_NAMES_CONF);
+    this.ignoredColumns = this.getString(SpoolDirCsvSourceConnectorConfig.CSV_IGNORED_COLUMNS_CONF);
   }
 
   static final ConfigDef conf() {
@@ -130,6 +135,7 @@ class SpoolDirCsvSourceConnectorConfig extends SpoolDirSourceConnectorConfig {
         .define(CSV_NULL_FIELD_INDICATOR_CONF, ConfigDef.Type.STRING, CSV_NULL_FIELD_INDICATOR_DEFAULT, ValidEnum.of(CSVReaderNullFieldIndicator.class), ConfigDef.Importance.LOW, CSV_NULL_FIELD_INDICATOR_DOC, CSV_GROUP, csvPosition++, ConfigDef.Width.LONG, CSV_DISPLAY_NAME)
         .define(CSV_FIRST_ROW_AS_HEADER_CONF, ConfigDef.Type.BOOLEAN, CSV_FIRST_ROW_AS_HEADER_DEFAULT, ConfigDef.Importance.MEDIUM, CSV_FIRST_ROW_AS_HEADER_DOC, CSV_GROUP, csvPosition++, ConfigDef.Width.LONG, CSV_DISPLAY_NAME)
         .define(CSV_CHARSET_CONF, ConfigDef.Type.STRING, CSV_CHARSET_DEFAULT, CharsetValidator.of(), ConfigDef.Importance.LOW, CSV_CHARSET_DOC, CSV_GROUP, csvPosition++, ConfigDef.Width.LONG, CSV_DISPLAY_NAME)
+        .define(CSV_IGNORED_COLUMNS_CONF, ConfigDef.Type.STRING, CSV_IGNORED_COLUMNS_DEFAULT, ConfigDef.Importance.LOW, CSV_IGNORED_COLUMNS_DOC, CSV_GROUP, csvPosition++, ConfigDef.Width.LONG, CSV_DISPLAY_NAME)
         .define(CSV_CASE_SENSITIVE_FIELD_NAMES_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, CSV_CASE_SENSITIVE_FIELD_NAMES_DOC);
   }
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTask.java
@@ -142,13 +142,17 @@ public class SpoolDirCsvSourceTask extends SpoolDirSourceTask<SpoolDirCsvSourceC
         row = currentRow;
       }
       log.trace("post checking for ignored columns");
-      log.info("currentRow has {} columns", currentRow.length);
-      log.info("row has {} columns", row.length);
+      log.trace("currentRow has {} columns", currentRow.length);
+      log.trace("row has {} columns", row.length);
 
       Struct keyStruct = new Struct(this.config.keySchema);
       Struct valueStruct = new Struct(this.config.valueSchema);
-      
 
+      if (row.length != this.fieldNames.length) {
+        log.info("Ignoring row because row has {} columns while fieldNames has {} columns", row.length, this.fieldNames.length);
+        continue;
+      }
+      
       for (int i = 0; i < this.fieldNames.length; i++) {
         String fieldName = this.fieldNames[i];
         


### PR DESCRIPTION
Added a new property that will allow for column skipping. If you want to skip columns 2,4,7 from a 11 column input file, add the following to the properties file

csv.ignored.columns=2,4,7