### PR TITLE
fix #88: update topic conf to kafka.topic to conform with prop standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 *.iml
 .okhttpcache
 ELFTesting.properties
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
             <artifactId>extended-log-format</artifactId>
             <version>[0.0.1.2, 0.0.1.1000)</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SchemaGenerator.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SchemaGenerator.java
@@ -64,7 +64,7 @@ public abstract class SchemaGenerator<CONFIG extends SpoolDirSourceConnectorConf
     defaultSettings.put(AbstractSourceConnectorConfig.ERROR_PATH_CONFIG, "/tmp/error");
     defaultSettings.put(SpoolDirSourceConnectorConfig.VALUE_SCHEMA_CONF, DUMMY_SCHEMA);
     defaultSettings.put(SpoolDirSourceConnectorConfig.KEY_SCHEMA_CONF, DUMMY_SCHEMA);
-    defaultSettings.put(AbstractSourceConnectorConfig.TOPIC_CONF, "dummy");
+    defaultSettings.put(AbstractSourceConnectorConfig.KAFKA_TOPIC_CONF, "dummy");
     defaultSettings.put(SpoolDirSourceConnectorConfig.SCHEMA_GENERATION_ENABLED_CONF, "true");
 
     DEFAULTS = ImmutableMap.copyOf(defaultSettings);

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SchemaGeneratorTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SchemaGeneratorTest.java
@@ -43,7 +43,7 @@ public class SchemaGeneratorTest {
     this.settings.put(AbstractSourceConnectorConfig.INPUT_PATH_CONFIG, this.inputPath.getAbsolutePath());
     this.settings.put(AbstractSourceConnectorConfig.FINISHED_PATH_CONFIG, this.finishedPath.getAbsolutePath());
     this.settings.put(AbstractSourceConnectorConfig.ERROR_PATH_CONFIG, this.errorPath.getAbsolutePath());
-    this.settings.put(AbstractSourceConnectorConfig.TOPIC_CONF, "dummy");
+    this.settings.put(AbstractSourceConnectorConfig.KAFKA_TOPIC_CONF, "dummy");
   }
 
 }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnectorConfigTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnectorConfigTest.java
@@ -4,22 +4,30 @@ package com.github.jcustenborder.kafka.connect.spooldir;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.ICSVParser;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SpoolDirCsvSourceConnectorConfigTest {
+  private static final String KAFKA_TOPIC_VALUE = "kafka.topic.config.value";
+  private static final String TOPIC_VALUE = "topic.config.value";
+  private Map<String, String> settings;
 
-  @Test
-  public void nullFieldSeparator() throws IOException {
-    Map<String, String> settings = new HashMap<>();
+  @BeforeEach
+  public void setup() {
+    settings = new HashMap<>();
     settings.put(SpoolDirCsvSourceConnectorConfig.CSV_SEPARATOR_CHAR_CONF, "0");
-    settings.put(SpoolDirCsvSourceConnectorConfig.TOPIC_CONF, "test");
+    settings.put(SpoolDirCsvSourceConnectorConfig.KAFKA_TOPIC_CONF, KAFKA_TOPIC_VALUE);
     settings.put(SpoolDirCsvSourceConnectorConfig.INPUT_PATH_CONFIG, "/tmp");
     settings.put(SpoolDirCsvSourceConnectorConfig.INPUT_FILE_PATTERN_CONF, "^.+$");
     settings.put(SpoolDirCsvSourceConnectorConfig.ERROR_PATH_CONFIG, "/tmp");
@@ -46,10 +54,16 @@ public class SpoolDirCsvSourceConnectorConfigTest {
         "      }\n" +
         "    }\n" +
         "  }");
+  }
+
+
+  @Test
+  public void nullFieldSeparator() throws IOException {
     SpoolDirCsvSourceConnectorConfig config = new SpoolDirCsvSourceConnectorConfig(
         true,
         settings
     );
+
     ICSVParser parser = config.createCSVParserBuilder();
     try (StringReader reader = new StringReader("id\u0000test\n123\u0000foo")) {
       CSVReaderBuilder readerBuilder = config.createCSVReaderBuilder(reader, parser);
@@ -62,4 +76,36 @@ public class SpoolDirCsvSourceConnectorConfigTest {
     }
   }
 
+  @Test
+  public void nullTopicConfigThrowsIllegalStateException() {
+    settings.put(SpoolDirCsvSourceConnectorConfig.KAFKA_TOPIC_CONF, null);
+    settings.put(SpoolDirCsvSourceConnectorConfig.TOPIC_CONF, null);
+
+    assertThrows(IllegalStateException.class, () -> {
+      new SpoolDirCsvSourceConnectorConfig(true, settings);
+    });
+  }
+
+  @ParameterizedTest(name = "topic ConfigDef compatibility - 'kafka.topic' config: {0}, 'topic' config: {1}, expected: {2}")
+  @MethodSource("createTopicTestArgs")
+  public void kafkaTopicBackwardsCompatible(String kafkaTopicConf, String topicConf, String expected) {
+    settings.put(SpoolDirCsvSourceConnectorConfig.KAFKA_TOPIC_CONF, kafkaTopicConf);
+    settings.put(SpoolDirCsvSourceConnectorConfig.TOPIC_CONF, topicConf);
+
+    SpoolDirCsvSourceConnectorConfig config = new SpoolDirCsvSourceConnectorConfig(true, settings);
+
+    assertEquals(expected, config.topic, "topic was not the expected value");
+  }
+
+  /**
+   * Generates a stream of Arguments for the kafkaTopicBackwardsCompatible @ParameterizedTest
+   *
+   * @return Stream<Arguments> that are used as the test cases
+   */
+  private static Stream<Arguments> createTopicTestArgs() {
+    return Stream.of(
+        Arguments.of(null, TOPIC_VALUE, TOPIC_VALUE),
+        Arguments.of(KAFKA_TOPIC_VALUE, TOPIC_VALUE, KAFKA_TOPIC_VALUE),
+        Arguments.of(KAFKA_TOPIC_VALUE, null, KAFKA_TOPIC_VALUE));
+  }
 }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirSourceConnectorTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirSourceConnectorTest.java
@@ -68,7 +68,7 @@ public abstract class SpoolDirSourceConnectorTest<T extends SpoolDirSourceConnec
     this.settings.put(AbstractSourceConnectorConfig.INPUT_PATH_CONFIG, this.inputPath.getAbsolutePath());
     this.settings.put(AbstractSourceConnectorConfig.FINISHED_PATH_CONFIG, this.finishedPath.getAbsolutePath());
     this.settings.put(AbstractSourceConnectorConfig.ERROR_PATH_CONFIG, this.errorPath.getAbsolutePath());
-    this.settings.put(AbstractSourceConnectorConfig.TOPIC_CONF, "dummy");
+    this.settings.put(AbstractSourceConnectorConfig.KAFKA_TOPIC_CONF, "dummy");
     this.settings.put(SpoolDirSourceConnectorConfig.SCHEMA_GENERATION_ENABLED_CONF, "true");
   }
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirSourceTaskTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirSourceTaskTest.java
@@ -85,7 +85,7 @@ public abstract class SpoolDirSourceTaskTest<T extends AbstractSourceTask> {
     settings.put(AbstractSourceConnectorConfig.FINISHED_PATH_CONFIG, this.finishedPath.getAbsolutePath());
     settings.put(AbstractSourceConnectorConfig.ERROR_PATH_CONFIG, this.errorPath.getAbsolutePath());
     settings.put(AbstractSourceConnectorConfig.INPUT_FILE_PATTERN_CONF, String.format("^.*\\.%s", packageName));
-    settings.put(AbstractSourceConnectorConfig.TOPIC_CONF, "testing");
+    settings.put(AbstractSourceConnectorConfig.KAFKA_TOPIC_CONF, "testing");
     settings.put(SpoolDirSourceConnectorConfig.KEY_SCHEMA_CONF, keySchemaConfig);
     settings.put(SpoolDirSourceConnectorConfig.VALUE_SCHEMA_CONF, valueSchemaConfig);
     settings.put(AbstractSourceConnectorConfig.EMPTY_POLL_WAIT_MS_CONF, "10");

--- a/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnector/schema.json
+++ b/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnector/schema.json
@@ -7,7 +7,7 @@
     "input.path": "/tmp",
     "error.path": "/tmp",
     "input.file.pattern": "^users\\d+\\.csv",
-    "topic": "users",
+    "kafka.topic": "users",
     "key.schema": "{\n  \"name\" : \"com.example.users.UserKey\",\n  \"type\" : \"STRUCT\",\n  \"isOptional\" : false,\n  \"fieldSchemas\" : {\n    \"id\" : {\n      \"type\" : \"INT64\",\n      \"isOptional\" : false\n    }\n  }\n}\n",
     "value.schema": "{\n  \"name\" : \"com.example.users.User\",\n  \"type\" : \"STRUCT\",\n  \"isOptional\" : false,\n  \"fieldSchemas\" : {\n    \"id\" : {\n      \"type\" : \"INT64\",\n      \"isOptional\" : false\n    },\n    \"first_name\" : {\n      \"type\" : \"STRING\",\n      \"isOptional\" : true\n    },\n    \"last_name\" : {\n      \"type\" : \"STRING\",\n      \"isOptional\" : true\n    },\n    \"email\" : {\n      \"type\" : \"STRING\",\n      \"isOptional\" : true\n    },\n    \"gender\" : {\n      \"type\" : \"STRING\",\n      \"isOptional\" : true\n    },\n    \"ip_address\" : {\n      \"type\" : \"STRING\",\n      \"isOptional\" : true\n    },\n    \"last_login\" : {\n      \"name\" : \"org.apache.kafka.connect.data.Timestamp\",\n      \"type\" : \"INT64\",\n      \"version\" : 1,\n      \"isOptional\" : false\n    },\n    \"account_balance\" : {\n      \"name\" : \"org.apache.kafka.connect.data.Decimal\",\n      \"type\" : \"BYTES\",\n      \"version\" : 1,\n      \"parameters\" : {\n        \"scale\" : \"2\"\n      },\n      \"isOptional\" : true\n    },\n    \"country\" : {\n      \"type\" : \"STRING\",\n      \"isOptional\" : true\n    },\n    \"favorite_color\" : {\n      \"type\" : \"STRING\",\n      \"isOptional\" : true\n    }\n  }\n}\n"
   }

--- a/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnector/tsv.json
+++ b/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnector/tsv.json
@@ -6,7 +6,7 @@
     "input.path": "/tmp",
     "error.path": "/tmp",
     "input.file.pattern": "^users\\d+\\.tsv",
-    "topic": "users",
+    "kafka.topic": "users",
     "csv.separator.char": 11
   }
 }

--- a/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirJsonSourceConnector/test.json
+++ b/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirJsonSourceConnector/test.json
@@ -6,6 +6,6 @@
     "input.path": "/tmp",
     "error.path": "/tmp",
     "input.file.pattern":"^users\\d+\\.json$",
-    "topic":"users"
+    "kafka.topic":"users"
   }
 }

--- a/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirLineDelimitedSourceConnector/fix.json
+++ b/src/test/resources/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirLineDelimitedSourceConnector/fix.json
@@ -2,7 +2,7 @@
   "description" : "This example will read files in a directory line by line and parse them using kafka-connect-transform-fix to a FIX representation of the data.",
   "name" : "FIX encoded lines",
   "config" : {
-    "topic" : "fix",
+    "kafka.topic" : "fix",
     "input.path" : "/tmp",
     "input.file.pattern" : "^.+\\.fix$",
     "error.path" : "/tmp",


### PR DESCRIPTION
Per requirements from Randall, updating the config def to conform to standards of having the topic config be `kafka.topic`.

Question for @jcustenborder - should we make this backward compatible (i.e. accept both inputs but pick `kafka.topics` when available or just force to updated config def)