### PR TITLE
#72 Remove processing file when stopping task if exists

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
@@ -126,7 +126,13 @@ public abstract class AbstractSourceTask<CONF extends AbstractSourceConnectorCon
 
   @Override
   public void stop() {
-
+    if (null != this.inputFile) {
+      File processingFile = InputFileDequeue.processingFile(this.config.processingFileExtension, this.inputFile);
+      if (processingFile.exists()) {
+        log.info("Stopping task but processing file still exists {}. Trying to remove it", processingFile);
+        processingFile.delete();
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
I can confirm the bug and this correction in my own environment.
No time to add some unit test, sorry.