### PR TITLE
Correct Connect Packaging plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
                             </tags>
                             <title>Kafka Connect Spooldir</title>
                             <supportProviderName>Confluent, Inc.</supportProviderName>
-                            <supportUrl>https://docs.confluent.io/current/</supportUrl>
+                            <supportUrl>https://docs.confluent.io/current/connect/kafka-connect-spooldir/</supportUrl>
                             <supportSummary><![CDATA[Confluent is introducing this preview connector to
                                         gain early feedback from developers. It should only be used for
                                         evaluation and non-production testing purposes or to provide

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
                 <version>0.11.2</version>
                 <executions>
                     <execution>
+                        <id>hub</id>
                         <goals>
                             <goal>kafka-connect</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -88,33 +88,41 @@
             <plugin>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-maven-plugin</artifactId>
-                <configuration>
-                    <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
-                    <documentationUrl>https://jcustenborder.github.io/kafka-connect-documentation/
-                    </documentationUrl>
-                    <componentTypes>
-                        <componentType>source</componentType>
-                    </componentTypes>
-                    <tags>
-                        <tag>File</tag>
-                        <tag>Flume</tag>
-                        <tag>csv</tag>
-                        <tag>json</tag>
-                    </tags>
-                    <title>Kafka Connect Spooldir</title>
-                    <supportProviderName>Confluent, Inc.</supportProviderName>
-                    <supportUrl>https://docs.confluent.io/current/</supportUrl>
-                    <supportSummary><![CDATA[Confluent is introducing this preview connector to
-                                gain early feedback from developers. It should only be used for
-                                evaluation and non-production testing purposes or to provide
-                                feedback to Confluent and is subject to the
-                                <a href="https://www.confluent.io/confluent-software-evaluation-license/">Confluent Software Evaluation License.</a>
-                                Confluent will provide support for this connector for evaluation and non-production testing purposes.
-                                 Comments, questions and suggestions related to preview features
-                                are encouraged. Confluent customers may submit questions and suggestions, and file support tickets via the
-                                <a href="https://support.confluent.io/">Confluent Support Portal.</a>]]>
-                    </supportSummary>
-                </configuration>
+                <version>0.11.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>kafka-connect</goal>
+                        </goals>
+                        <configuration>
+                            <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
+                            <documentationUrl>https://jcustenborder.github.io/kafka-connect-documentation/
+                            </documentationUrl>
+                            <componentTypes>
+                                <componentType>source</componentType>
+                            </componentTypes>
+                            <tags>
+                                <tag>File</tag>
+                                <tag>Flume</tag>
+                                <tag>csv</tag>
+                                <tag>json</tag>
+                            </tags>
+                            <title>Kafka Connect Spooldir</title>
+                            <supportProviderName>Confluent, Inc.</supportProviderName>
+                            <supportUrl>https://docs.confluent.io/current/</supportUrl>
+                            <supportSummary><![CDATA[Confluent is introducing this preview connector to
+                                        gain early feedback from developers. It should only be used for
+                                        evaluation and non-production testing purposes or to provide
+                                        feedback to Confluent and is subject to the
+                                        <a href="https://www.confluent.io/confluent-software-evaluation-license/">Confluent Software Evaluation License.</a>
+                                        Confluent will provide support for this connector for evaluation and non-production testing purposes.
+                                         Comments, questions and suggestions related to preview features
+                                        are encouraged. Confluent customers may submit questions and suggestions, and file support tickets via the
+                                        <a href="https://support.confluent.io/">Confluent Support Portal.</a>]]>
+                            </supportSummary>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The parent POM uses an older version of the `kafka-connect-maven-plugin` Maven plugin and it defines a number of configs as defaults. In order to override some of those configs, the plugin configuration in this project needs to define the configuration within the execution _and_ use the latest version of the plugin (0.11.2), and only then will configs from the parent and the project POM be properly merged. 

(Using `<configuration>` at the top without the `<executions>` element results in this project's configs being lost. Using 0.11.0 of the plugin also does not properly merge the two sets of configs.)