### PR TITLE
Clean up policy to move files to subdirectories by date in finished directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target
 *.iml
 .okhttpcache
 ELFTesting.properties
+.checkstyle
+.factorypath
+.idea/

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
@@ -51,7 +51,8 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   public static final String CLEANUP_POLICY_DOC = "Determines how the connector should cleanup the " +
       "files that have been successfully processed. NONE leaves the files in place which could " +
       "cause them to be reprocessed if the connector is restarted. DELETE removes the file from the " +
-      "filesystem. MOVE will move the file to a finished directory.";
+      "filesystem. MOVE will move the file to a finished directory. MOVEBYDATE will move the file to " +
+      "a finished directory with subdirectories by date";
   public static final String GROUP_FILESYSTEM = "File System";
   public static final String GROUP_GENERAL = "General";
   //DirectoryMonitorConfig
@@ -282,7 +283,8 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   public enum CleanupPolicy {
     NONE,
     DELETE,
-    MOVE
+    MOVE,
+    MOVEBYDATE
   }
 
   public enum FileAttribute {

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicyTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicyTest.java
@@ -1,0 +1,34 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MoveByDateCleanupPolicyTest extends AbstractCleanUpPolicyTest<AbstractCleanUpPolicy.MoveByDate> {
+  @Override
+  protected AbstractCleanUpPolicy.MoveByDate create(File inputFile, File errorPath, File finishedPath) {
+    return new AbstractCleanUpPolicy.MoveByDate(inputFile, errorPath, finishedPath);
+  }
+
+  @Test
+  public void success() throws IOException {
+    SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
+    Path subDirectory = Paths.get(this.finishedPath.getAbsolutePath(), dateFormatter.format(this.inputFile.lastModified()));
+    File finishedFile = new File(subDirectory.toFile(), this.inputFile.getName());
+
+    assertTrue(this.inputFile.exists(), "Input file should exist");
+    assertFalse(finishedFile.exists(), "Finished file should not exist");
+
+    this.cleanupPolicy.success();
+
+    assertFalse(this.inputFile.exists(), "Input file should not exist");
+    assertTrue(finishedFile.exists(), "Finished file should exist");
+  }
+}


### PR DESCRIPTION
The MOVE clean up policy moves all the processed files to a finished directory.  When processing lots of files in a day this folder can get quite large very quickly.  So large that it is no longer navigable, especially on a Windows machine.  This change adds a MOVEBYDATE clean up policy that will move the processed files to subdirectories by date, named as yyyy-mm-dd.  This will create the subdirectories as needed and move the files to the appropriate one based on the last modified date.