### PR TITLE
Bug fix - The MOVEBYDATE clean up policy was not setting up the finished path correctly.

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractCleanUpPolicy.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractCleanUpPolicy.java
@@ -61,10 +61,7 @@ abstract class AbstractCleanUpPolicy implements Closeable {
 
     return result;
   }
-
-
-
-
+  
   protected boolean createDirectory(File directory) {
     if (directory.exists()) {
       return true;

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
@@ -119,7 +119,7 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
     this.inputPath = ConfigUtils.getAbsoluteFile(this, INPUT_PATH_CONFIG);
     this.cleanupPolicy = ConfigUtils.getEnum(CleanupPolicy.class, this, CLEANUP_POLICY_CONF);
 
-    if (CleanupPolicy.MOVE == this.cleanupPolicy) {
+    if (CleanupPolicy.MOVE == this.cleanupPolicy || CleanupPolicy.MOVEBYDATE == this.cleanupPolicy) {
       this.finishedPath = ConfigUtils.getAbsoluteFile(this, FINISHED_PATH_CONFIG);
     } else {
       this.finishedPath = null;

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
@@ -112,7 +112,8 @@ public abstract class AbstractSourceTask<CONF extends AbstractSourceConnectorCon
     checkDirectory(AbstractSourceConnectorConfig.INPUT_PATH_CONFIG, this.config.inputPath);
     checkDirectory(AbstractSourceConnectorConfig.ERROR_PATH_CONFIG, this.config.errorPath);
 
-    if (AbstractSourceConnectorConfig.CleanupPolicy.MOVE == this.config.cleanupPolicy) {
+    if (AbstractSourceConnectorConfig.CleanupPolicy.MOVE == this.config.cleanupPolicy ||
+        AbstractSourceConnectorConfig.CleanupPolicy.MOVEBYDATE == this.config.cleanupPolicy) {
       checkDirectory(AbstractSourceConnectorConfig.FINISHED_PATH_CONFIG, this.config.finishedPath);
     }
 


### PR DESCRIPTION
I missed two places for the finishedPath.  First pulling it from the config the same way the MOVE policy did.  Then second checking for its existence and writability, like the MOVE policy.