### PR TITLE
Change log level when searching for files

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFileDequeue.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFileDequeue.java
@@ -48,10 +48,10 @@ public class InputFileDequeue extends ForwardingDeque<InputFile> {
       return files;
     }
 
-    log.info("Searching for file(s) in {}", this.config.inputPath);
+    log.debug("Searching for file(s) in {}", this.config.inputPath);
     File[] input = this.config.inputPath.listFiles(this.config.inputFilenameFilter);
     if (null == input || input.length == 0) {
-      log.info("No files matching {} were found in {}", AbstractSourceConnectorConfig.INPUT_FILE_PATTERN_CONF, this.config.inputPath);
+      log.debug("No files matching {} were found in {}", AbstractSourceConnectorConfig.INPUT_FILE_PATTERN_CONF, this.config.inputPath);
       return new ArrayDeque<>();
     }
     Arrays.sort(input, Comparator.comparing(File::getName));


### PR DESCRIPTION
I suggest to change to log level from _info_ to _debug_ when the connector is searching for files in a directory. It's difficult to visualize the logs with this event being generated multiple time per second.