### PR TITLE
Changing to correct Task SpoolDirBinaryFileSourceTask

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirBinaryFileSourceConnector.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirBinaryFileSourceConnector.java
@@ -39,7 +39,7 @@ public class SpoolDirBinaryFileSourceConnector extends AbstractSourceConnector<S
 
   @Override
   public Class<? extends Task> taskClass() {
-    return SpoolDirLineDelimitedSourceTask.class;
+    return SpoolDirBinaryFileSourceTask.class;
   }
 
   @Override


### PR DESCRIPTION
SpoolDirBinaryFileSourceConnector should reference task SpoolDirBinaryFileSourceTask