### PR TITLE
Support for recursive walking of input.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,26 @@ Before a file is processed, a flag is created in its directory to indicate the f
 
 *Validator:* Matches regex( ^.*\..+$ )
 
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.input.path.sub.dir.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+*Default Value:* false
+
+##### `input.path.walk.recursively.retain.sub.dirs`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+*Default Value:* false
+
 
 #### General
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,13 @@ to run the plugin.
 
 
 # Source Connectors
-## [Schema Less Json Source Connector](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-spooldir/sources/SpoolDirSchemaLessJsonSourceConnector.html)
+## [Extended Log File Format Source Connector](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-spooldir/sources/SpoolDirELFSourceConnector.html)
 
 ```
-com.github.jcustenborder.kafka.connect.spooldir.SpoolDirSchemaLessJsonSourceConnector
+com.github.jcustenborder.kafka.connect.spooldir.elf.SpoolDirELFSourceConnector
 ```
 
-This connector is used to `stream <https://en.wikipedia.org/wiki/JSON_Streaming>_` JSON files from a directory while converting the data based on the schema supplied in the configuration. This connector will read each file node by node writing the result to Kafka. For example if your data file contains several json objects the connector will read from { to } for each object and write each object to Kafka.
-### Important
-
-This connector does not try to convert the json records to a schema. The recommended converter to use is the StringConverter. Example: `value.converter=org.apache.kafka.connect.storage.StringConverter`
+This connector is used to stream `Extended Log File Format <https://www.w3.org/TR/WD-logfile.html>` files from a directory while converting the data to a strongly typed schema.
 ### Configuration
 
 #### File System
@@ -126,6 +123,16 @@ The task partitioner implementation is used when the connector is configured to 
 
 
 
+##### `cleanup.policy.maintain.relative.path`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
 ##### `file.buffer.size.bytes`
 
 The size of buffer for the BufferedInputStream that will be used to interact with the file system.
@@ -168,6 +175,16 @@ The attributes each file will use to determine the sort order. `Name` is name of
 
 
 
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
 ##### `processing.file.extension`
 
 Before a file is processed, a flag is created in its directory to indicate the file is being handled. The flag file has the same name as the file, but with this property appended as a suffix.
@@ -179,26 +196,6 @@ Before a file is processed, a flag is created in its directory to indicate the f
 *Default Value:* .PROCESSING
 
 *Validator:* Matches regex( ^.*\..+$ )
-
-##### `input.path.walk.recursively`
-
-If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.input.path.sub.dir.path`
-
-*Importance:* LOW
-
-*Type:* BOOLEAN
-
-*Default Value:* false
-
-##### `input.path.walk.recursively.retain.sub.dirs`
-
-If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
-
-*Importance:* LOW
-
-*Type:* BOOLEAN
-
-*Default Value:* false
 
 
 #### General
@@ -237,20 +234,6 @@ The amount of time to wait if a poll returns an empty list of records.
 *Default Value:* 500
 
 *Validator:* [1,...,9223372036854775807]
-
-
-
-##### `file.charset`
-
-Character set to read wth file with.
-
-*Importance:* LOW
-
-*Type:* STRING
-
-*Default Value:* UTF-8
-
-*Validator:* Big5,Big5-HKSCS,CESU-8,EUC-JP,EUC-KR,GB18030,GB2312,GBK,IBM-Thai,IBM00858,IBM01140,IBM01141,IBM01142,IBM01143,IBM01144,IBM01145,IBM01146,IBM01147,IBM01148,IBM01149,IBM037,IBM1026,IBM1047,IBM273,IBM277,IBM278,IBM280,IBM284,IBM285,IBM290,IBM297,IBM420,IBM424,IBM437,IBM500,IBM775,IBM850,IBM852,IBM855,IBM857,IBM860,IBM861,IBM862,IBM863,IBM864,IBM865,IBM866,IBM868,IBM869,IBM870,IBM871,IBM918,ISO-2022-CN,ISO-2022-JP,ISO-2022-JP-2,ISO-2022-KR,ISO-8859-1,ISO-8859-13,ISO-8859-15,ISO-8859-16,ISO-8859-2,ISO-8859-3,ISO-8859-4,ISO-8859-5,ISO-8859-6,ISO-8859-7,ISO-8859-8,ISO-8859-9,JIS_X0201,JIS_X0212-1990,KOI8-R,KOI8-U,Shift_JIS,TIS-620,US-ASCII,UTF-16,UTF-16BE,UTF-16LE,UTF-32,UTF-32BE,UTF-32LE,UTF-8,windows-1250,windows-1251,windows-1252,windows-1253,windows-1254,windows-1255,windows-1256,windows-1257,windows-1258,windows-31j,x-Big5-HKSCS-2001,x-Big5-Solaris,x-euc-jp-linux,x-EUC-TW,x-eucJP-Open,x-IBM1006,x-IBM1025,x-IBM1046,x-IBM1097,x-IBM1098,x-IBM1112,x-IBM1122,x-IBM1123,x-IBM1124,x-IBM1129,x-IBM1166,x-IBM1364,x-IBM1381,x-IBM1383,x-IBM29626C,x-IBM300,x-IBM33722,x-IBM737,x-IBM833,x-IBM834,x-IBM856,x-IBM874,x-IBM875,x-IBM921,x-IBM922,x-IBM930,x-IBM933,x-IBM935,x-IBM937,x-IBM939,x-IBM942,x-IBM942C,x-IBM943,x-IBM943C,x-IBM948,x-IBM949,x-IBM949C,x-IBM950,x-IBM964,x-IBM970,x-ISCII91,x-ISO-2022-CN-CNS,x-ISO-2022-CN-GB,x-iso-8859-11,x-JIS0208,x-JISAutoDetect,x-Johab,x-MacArabic,x-MacCentralEurope,x-MacCroatian,x-MacCyrillic,x-MacDingbat,x-MacGreek,x-MacHebrew,x-MacIceland,x-MacRoman,x-MacRomania,x-MacSymbol,x-MacThai,x-MacTurkish,x-MacUkraine,x-MS932_0213,x-MS950-HKSCS,x-MS950-HKSCS-XP,x-mswin-936,x-PCK,x-SJIS_0213,x-UTF-16LE-BOM,X-UTF-32BE-BOM,X-UTF-32LE-BOM,x-windows-50220,x-windows-50221,x-windows-874,x-windows-949,x-windows-950,x-windows-iso2022jp
 
 
 
@@ -409,6 +392,16 @@ The task partitioner implementation is used when the connector is configured to 
 
 
 
+##### `cleanup.policy.maintain.relative.path`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
 ##### `file.buffer.size.bytes`
 
 The size of buffer for the BufferedInputStream that will be used to interact with the file system.
@@ -448,6 +441,16 @@ The attributes each file will use to determine the sort order. `Name` is name of
 *Default Value:* [NameAsc]
 
 *Validator:* Matches: ``NameAsc``, ``NameDesc``, ``LengthAsc``, ``LengthDesc``, ``LastModifiedAsc``, ``LastModifiedDesc``
+
+
+
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
 
 
 
@@ -649,246 +652,6 @@ The timezone that all of the dates will be parsed with.
 
 
 
-## [Binary File Source Connector](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-spooldir/sources/SpoolDirBinaryFileSourceConnector.html)
-
-```
-com.github.jcustenborder.kafka.connect.spooldir.SpoolDirBinaryFileSourceConnector
-```
-
-This connector is used to read an entire file as a byte array write the data to Kafka.
-### Warning
-
-Large files will be read as a single byte array. This means that the process could run out of memory or try to send a message to Kafka that is greater than the max message size. If this happens an exception will be thrown.
-### Important
-
-The recommended converter to use is the ByteArrayConverter. Example: `value.converter=org.apache.kafka.connect.storage.ByteArrayConverter`
-### Configuration
-
-#### File System
-
-
-##### `error.path`
-
-The directory to place files in which have error(s). This directory must exist and be writable by the user running Kafka Connect.
-
-*Importance:* HIGH
-
-*Type:* STRING
-
-*Validator:* Absolute path to a directory that exists and is writable.
-
-
-
-##### `input.file.pattern`
-
-Regular expression to check input file names against. This expression must match the entire filename. The equivalent of Matcher.matches().
-
-*Importance:* HIGH
-
-*Type:* STRING
-
-
-
-##### `input.path`
-
-The directory to read files that will be processed. This directory must exist and be writable by the user running Kafka Connect.
-
-*Importance:* HIGH
-
-*Type:* STRING
-
-*Validator:* Absolute path to a directory that exists and is writable.
-
-
-
-##### `finished.path`
-
-The directory to place files that have been successfully processed. This directory must exist and be writable by the user running Kafka Connect.
-
-*Importance:* HIGH
-
-*Type:* STRING
-
-
-
-##### `halt.on.error`
-
-Should the task halt when it encounters an error or continue to the next file.
-
-*Importance:* HIGH
-
-*Type:* BOOLEAN
-
-*Default Value:* true
-
-
-
-##### `cleanup.policy`
-
-Determines how the connector should cleanup the files that have been successfully processed. NONE leaves the files in place which could cause them to be reprocessed if the connector is restarted. DELETE removes the file from the filesystem. MOVE will move the file to a finished directory. MOVEBYDATE will move the file to a finished directory with subdirectories by date
-
-*Importance:* MEDIUM
-
-*Type:* STRING
-
-*Default Value:* MOVE
-
-*Validator:* Matches: ``NONE``, ``DELETE``, ``MOVE``, ``MOVEBYDATE``
-
-
-
-##### `task.partitioner`
-
-The task partitioner implementation is used when the connector is configured to use more than one task. This is used by each task to identify which files will be processed by that task. This ensures that each file is only assigned to one task.
-
-*Importance:* MEDIUM
-
-*Type:* STRING
-
-*Default Value:* ByName
-
-*Validator:* Matches: ``ByName``
-
-
-
-##### `file.buffer.size.bytes`
-
-The size of buffer for the BufferedInputStream that will be used to interact with the file system.
-
-*Importance:* LOW
-
-*Type:* INT
-
-*Default Value:* 131072
-
-*Validator:* [1,...]
-
-
-
-##### `file.minimum.age.ms`
-
-The amount of time in milliseconds after the file was last written to before the file can be processed.
-
-*Importance:* LOW
-
-*Type:* LONG
-
-*Default Value:* 0
-
-*Validator:* [0,...]
-
-
-
-##### `files.sort.attributes`
-
-The attributes each file will use to determine the sort order. `Name` is name of the file. `Length` is the length of the file preferring larger files first. `LastModified` is the LastModified attribute of the file preferring older files first.
-
-*Importance:* LOW
-
-*Type:* LIST
-
-*Default Value:* [NameAsc]
-
-*Validator:* Matches: ``NameAsc``, ``NameDesc``, ``LengthAsc``, ``LengthDesc``, ``LastModifiedAsc``, ``LastModifiedDesc``
-
-
-
-##### `processing.file.extension`
-
-Before a file is processed, a flag is created in its directory to indicate the file is being handled. The flag file has the same name as the file, but with this property appended as a suffix.
-
-*Importance:* LOW
-
-*Type:* STRING
-
-*Default Value:* .PROCESSING
-
-*Validator:* Matches regex( ^.*\..+$ )
-
-
-#### General
-
-
-##### `topic`
-
-The Kafka topic to write the data to.
-
-*Importance:* HIGH
-
-*Type:* STRING
-
-
-
-##### `batch.size`
-
-The number of records that should be returned with each batch.
-
-*Importance:* LOW
-
-*Type:* INT
-
-*Default Value:* 1000
-
-
-
-##### `empty.poll.wait.ms`
-
-The amount of time to wait if a poll returns an empty list of records.
-
-*Importance:* LOW
-
-*Type:* LONG
-
-*Default Value:* 500
-
-*Validator:* [1,...,9223372036854775807]
-
-
-
-##### `task.count`
-
-Internal setting to the connector used to instruct a task on which files to select. The connector will override this setting.
-
-*Importance:* LOW
-
-*Type:* INT
-
-*Default Value:* 1
-
-*Validator:* [1,...]
-
-
-
-##### `task.index`
-
-Internal setting to the connector used to instruct a task on which files to select. The connector will override this setting.
-
-*Importance:* LOW
-
-*Type:* INT
-
-*Default Value:* 0
-
-*Validator:* [0,...]
-
-
-#### Timestamps
-
-
-##### `timestamp.mode`
-
-Determines how the connector will set the timestamp for the [ConnectRecord](https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/connector/ConnectRecord.html#timestamp()). If set to `Field` then the timestamp will be read from a field in the value. This field cannot be optional and must be a [Timestamp](https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.html). Specify the field  in `timestamp.field`. If set to `FILE_TIME` then the last modified time of the file will be used. If set to `PROCESS_TIME` the time the record is read will be used.
-
-*Importance:* MEDIUM
-
-*Type:* STRING
-
-*Default Value:* PROCESS_TIME
-
-*Validator:* Matches: ``FIELD``, ``FILE_TIME``, ``PROCESS_TIME``
-
-
-
 ## [Line Delimited Source Connector](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-spooldir/sources/SpoolDirLineDelimitedSourceConnector.html)
 
 ```
@@ -988,6 +751,16 @@ The task partitioner implementation is used when the connector is configured to 
 
 
 
+##### `cleanup.policy.maintain.relative.path`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
 ##### `file.buffer.size.bytes`
 
 The size of buffer for the BufferedInputStream that will be used to interact with the file system.
@@ -1027,6 +800,16 @@ The attributes each file will use to determine the sort order. `Name` is name of
 *Default Value:* [NameAsc]
 
 *Validator:* Matches: ``NameAsc``, ``NameDesc``, ``LengthAsc``, ``LengthDesc``, ``LastModifiedAsc``, ``LastModifiedDesc``
+
+
+
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
 
 
 
@@ -1146,7 +929,10 @@ Determines how the connector will set the timestamp for the [ConnectRecord](http
 com.github.jcustenborder.kafka.connect.spooldir.SpoolDirAvroSourceConnector
 ```
 
-This connector is used to read avro data files from the file system and write their contents to kafka.
+This connector is used to read avro data files from the file system and write their contents to Kafka. The schema of the file is used to read the data and produce it to Kafka
+### Important
+
+This connector has a dependency on the Confluent Schema Registry specifically kafka-connect-avro-converter. This dependency is not shipped along with the connector to ensure that there are not potential version mismatch issues. The easiest way to ensure this component is available is to use one of the Confluent packages or containers for deployment.
 ### Configuration
 
 #### File System
@@ -1236,6 +1022,16 @@ The task partitioner implementation is used when the connector is configured to 
 
 
 
+##### `cleanup.policy.maintain.relative.path`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
 ##### `file.buffer.size.bytes`
 
 The size of buffer for the BufferedInputStream that will be used to interact with the file system.
@@ -1275,6 +1071,16 @@ The attributes each file will use to determine the sort order. `Name` is name of
 *Default Value:* [NameAsc]
 
 *Validator:* Matches: ``NameAsc``, ``NameDesc``, ``LengthAsc``, ``LengthDesc``, ``LastModifiedAsc``, ``LastModifiedDesc``
+
+
+
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
 
 
 
@@ -1374,13 +1180,16 @@ Determines how the connector will set the timestamp for the [ConnectRecord](http
 
 
 
-## [Extended Log File Format Source Connector](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-spooldir/sources/SpoolDirELFSourceConnector.html)
+## [Schema Less Json Source Connector](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-spooldir/sources/SpoolDirSchemaLessJsonSourceConnector.html)
 
 ```
-com.github.jcustenborder.kafka.connect.spooldir.elf.SpoolDirELFSourceConnector
+com.github.jcustenborder.kafka.connect.spooldir.SpoolDirSchemaLessJsonSourceConnector
 ```
 
-This connector is used to stream `Extended Log File Format <https://www.w3.org/TR/WD-logfile.html>` files from a directory while converting the data to a strongly typed schema.
+This connector is used to `stream <https://en.wikipedia.org/wiki/JSON_Streaming>_` JSON files from a directory while converting the data based on the schema supplied in the configuration. This connector will read each file node by node writing the result to Kafka. For example if your data file contains several json objects the connector will read from { to } for each object and write each object to Kafka.
+### Important
+
+This connector does not try to convert the json records to a schema. The recommended converter to use is the StringConverter. Example: `value.converter=org.apache.kafka.connect.storage.StringConverter`
 ### Configuration
 
 #### File System
@@ -1470,6 +1279,16 @@ The task partitioner implementation is used when the connector is configured to 
 
 
 
+##### `cleanup.policy.maintain.relative.path`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
 ##### `file.buffer.size.bytes`
 
 The size of buffer for the BufferedInputStream that will be used to interact with the file system.
@@ -1509,6 +1328,290 @@ The attributes each file will use to determine the sort order. `Name` is name of
 *Default Value:* [NameAsc]
 
 *Validator:* Matches: ``NameAsc``, ``NameDesc``, ``LengthAsc``, ``LengthDesc``, ``LastModifiedAsc``, ``LastModifiedDesc``
+
+
+
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
+##### `processing.file.extension`
+
+Before a file is processed, a flag is created in its directory to indicate the file is being handled. The flag file has the same name as the file, but with this property appended as a suffix.
+
+*Importance:* LOW
+
+*Type:* STRING
+
+*Default Value:* .PROCESSING
+
+*Validator:* Matches regex( ^.*\..+$ )
+
+
+#### General
+
+
+##### `topic`
+
+The Kafka topic to write the data to.
+
+*Importance:* HIGH
+
+*Type:* STRING
+
+
+
+##### `batch.size`
+
+The number of records that should be returned with each batch.
+
+*Importance:* LOW
+
+*Type:* INT
+
+*Default Value:* 1000
+
+
+
+##### `empty.poll.wait.ms`
+
+The amount of time to wait if a poll returns an empty list of records.
+
+*Importance:* LOW
+
+*Type:* LONG
+
+*Default Value:* 500
+
+*Validator:* [1,...,9223372036854775807]
+
+
+
+##### `file.charset`
+
+Character set to read wth file with.
+
+*Importance:* LOW
+
+*Type:* STRING
+
+*Default Value:* UTF-8
+
+*Validator:* Big5,Big5-HKSCS,CESU-8,EUC-JP,EUC-KR,GB18030,GB2312,GBK,IBM-Thai,IBM00858,IBM01140,IBM01141,IBM01142,IBM01143,IBM01144,IBM01145,IBM01146,IBM01147,IBM01148,IBM01149,IBM037,IBM1026,IBM1047,IBM273,IBM277,IBM278,IBM280,IBM284,IBM285,IBM290,IBM297,IBM420,IBM424,IBM437,IBM500,IBM775,IBM850,IBM852,IBM855,IBM857,IBM860,IBM861,IBM862,IBM863,IBM864,IBM865,IBM866,IBM868,IBM869,IBM870,IBM871,IBM918,ISO-2022-CN,ISO-2022-JP,ISO-2022-JP-2,ISO-2022-KR,ISO-8859-1,ISO-8859-13,ISO-8859-15,ISO-8859-16,ISO-8859-2,ISO-8859-3,ISO-8859-4,ISO-8859-5,ISO-8859-6,ISO-8859-7,ISO-8859-8,ISO-8859-9,JIS_X0201,JIS_X0212-1990,KOI8-R,KOI8-U,Shift_JIS,TIS-620,US-ASCII,UTF-16,UTF-16BE,UTF-16LE,UTF-32,UTF-32BE,UTF-32LE,UTF-8,windows-1250,windows-1251,windows-1252,windows-1253,windows-1254,windows-1255,windows-1256,windows-1257,windows-1258,windows-31j,x-Big5-HKSCS-2001,x-Big5-Solaris,x-euc-jp-linux,x-EUC-TW,x-eucJP-Open,x-IBM1006,x-IBM1025,x-IBM1046,x-IBM1097,x-IBM1098,x-IBM1112,x-IBM1122,x-IBM1123,x-IBM1124,x-IBM1129,x-IBM1166,x-IBM1364,x-IBM1381,x-IBM1383,x-IBM29626C,x-IBM300,x-IBM33722,x-IBM737,x-IBM833,x-IBM834,x-IBM856,x-IBM874,x-IBM875,x-IBM921,x-IBM922,x-IBM930,x-IBM933,x-IBM935,x-IBM937,x-IBM939,x-IBM942,x-IBM942C,x-IBM943,x-IBM943C,x-IBM948,x-IBM949,x-IBM949C,x-IBM950,x-IBM964,x-IBM970,x-ISCII91,x-ISO-2022-CN-CNS,x-ISO-2022-CN-GB,x-iso-8859-11,x-JIS0208,x-JISAutoDetect,x-Johab,x-MacArabic,x-MacCentralEurope,x-MacCroatian,x-MacCyrillic,x-MacDingbat,x-MacGreek,x-MacHebrew,x-MacIceland,x-MacRoman,x-MacRomania,x-MacSymbol,x-MacThai,x-MacTurkish,x-MacUkraine,x-MS932_0213,x-MS950-HKSCS,x-MS950-HKSCS-XP,x-mswin-936,x-PCK,x-SJIS_0213,x-UTF-16LE-BOM,X-UTF-32BE-BOM,X-UTF-32LE-BOM,x-windows-50220,x-windows-50221,x-windows-874,x-windows-949,x-windows-950,x-windows-iso2022jp
+
+
+
+##### `task.count`
+
+Internal setting to the connector used to instruct a task on which files to select. The connector will override this setting.
+
+*Importance:* LOW
+
+*Type:* INT
+
+*Default Value:* 1
+
+*Validator:* [1,...]
+
+
+
+##### `task.index`
+
+Internal setting to the connector used to instruct a task on which files to select. The connector will override this setting.
+
+*Importance:* LOW
+
+*Type:* INT
+
+*Default Value:* 0
+
+*Validator:* [0,...]
+
+
+#### Timestamps
+
+
+##### `timestamp.mode`
+
+Determines how the connector will set the timestamp for the [ConnectRecord](https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/connector/ConnectRecord.html#timestamp()). If set to `Field` then the timestamp will be read from a field in the value. This field cannot be optional and must be a [Timestamp](https://kafka.apache.org/0102/javadoc/org/apache/kafka/connect/data/Schema.html). Specify the field  in `timestamp.field`. If set to `FILE_TIME` then the last modified time of the file will be used. If set to `PROCESS_TIME` the time the record is read will be used.
+
+*Importance:* MEDIUM
+
+*Type:* STRING
+
+*Default Value:* PROCESS_TIME
+
+*Validator:* Matches: ``FIELD``, ``FILE_TIME``, ``PROCESS_TIME``
+
+
+
+## [Binary File Source Connector](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-spooldir/sources/SpoolDirBinaryFileSourceConnector.html)
+
+```
+com.github.jcustenborder.kafka.connect.spooldir.SpoolDirBinaryFileSourceConnector
+```
+
+This connector is used to read an entire file as a byte array write the data to Kafka.
+### Warning
+
+Large files will be read as a single byte array. This means that the process could run out of memory or try to send a message to Kafka that is greater than the max message size. If this happens an exception will be thrown.
+### Important
+
+The recommended converter to use is the ByteArrayConverter. Example: `value.converter=org.apache.kafka.connect.storage.ByteArrayConverter`
+### Configuration
+
+#### File System
+
+
+##### `error.path`
+
+The directory to place files in which have error(s). This directory must exist and be writable by the user running Kafka Connect.
+
+*Importance:* HIGH
+
+*Type:* STRING
+
+*Validator:* Absolute path to a directory that exists and is writable.
+
+
+
+##### `input.file.pattern`
+
+Regular expression to check input file names against. This expression must match the entire filename. The equivalent of Matcher.matches().
+
+*Importance:* HIGH
+
+*Type:* STRING
+
+
+
+##### `input.path`
+
+The directory to read files that will be processed. This directory must exist and be writable by the user running Kafka Connect.
+
+*Importance:* HIGH
+
+*Type:* STRING
+
+*Validator:* Absolute path to a directory that exists and is writable.
+
+
+
+##### `finished.path`
+
+The directory to place files that have been successfully processed. This directory must exist and be writable by the user running Kafka Connect.
+
+*Importance:* HIGH
+
+*Type:* STRING
+
+
+
+##### `halt.on.error`
+
+Should the task halt when it encounters an error or continue to the next file.
+
+*Importance:* HIGH
+
+*Type:* BOOLEAN
+
+*Default Value:* true
+
+
+
+##### `cleanup.policy`
+
+Determines how the connector should cleanup the files that have been successfully processed. NONE leaves the files in place which could cause them to be reprocessed if the connector is restarted. DELETE removes the file from the filesystem. MOVE will move the file to a finished directory. MOVEBYDATE will move the file to a finished directory with subdirectories by date
+
+*Importance:* MEDIUM
+
+*Type:* STRING
+
+*Default Value:* MOVE
+
+*Validator:* Matches: ``NONE``, ``DELETE``, ``MOVE``, ``MOVEBYDATE``
+
+
+
+##### `task.partitioner`
+
+The task partitioner implementation is used when the connector is configured to use more than one task. This is used by each task to identify which files will be processed by that task. This ensures that each file is only assigned to one task.
+
+*Importance:* MEDIUM
+
+*Type:* STRING
+
+*Default Value:* ByName
+
+*Validator:* Matches: ``ByName``
+
+
+
+##### `cleanup.policy.maintain.relative.path`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+
+
+##### `file.buffer.size.bytes`
+
+The size of buffer for the BufferedInputStream that will be used to interact with the file system.
+
+*Importance:* LOW
+
+*Type:* INT
+
+*Default Value:* 131072
+
+*Validator:* [1,...]
+
+
+
+##### `file.minimum.age.ms`
+
+The amount of time in milliseconds after the file was last written to before the file can be processed.
+
+*Importance:* LOW
+
+*Type:* LONG
+
+*Default Value:* 0
+
+*Validator:* [0,...]
+
+
+
+##### `files.sort.attributes`
+
+The attributes each file will use to determine the sort order. `Name` is name of the file. `Length` is the length of the file preferring larger files first. `LastModified` is the LastModified attribute of the file preferring older files first.
+
+*Importance:* LOW
+
+*Type:* LIST
+
+*Default Value:* [NameAsc]
+
+*Validator:* Matches: ``NameAsc``, ``NameDesc``, ``LengthAsc``, ``LengthDesc``, ``LastModifiedAsc``, ``LastModifiedDesc``
+
+
+
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
 
 
 
@@ -1717,6 +1820,18 @@ The task partitioner implementation is used when the connector is configured to 
 
 
 
+##### `cleanup.policy.maintain.relative.path`
+
+If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+*Default Value:* false
+
+
+
 ##### `file.buffer.size.bytes`
 
 The size of buffer for the BufferedInputStream that will be used to interact with the file system.
@@ -1757,6 +1872,17 @@ The attributes each file will use to determine the sort order. `Name` is name of
 
 *Validator:* Matches: ``NameAsc``, ``NameDesc``, ``LengthAsc``, ``LengthDesc``, ``LastModifiedAsc``, ``LastModifiedDesc``
 
+
+
+##### `input.path.walk.recursively`
+
+If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`
+
+*Importance:* LOW
+
+*Type:* BOOLEAN
+
+*Default Value:* false
 
 
 ##### `processing.file.extension`

--- a/config/CSVExample-subdir-walk.json
+++ b/config/CSVExample-subdir-walk.json
@@ -14,6 +14,6 @@
     "key.schema": "{\"name\":\"com.example.users.UserKey\",\"type\":\"STRUCT\",\"isOptional\":false,\"fieldSchemas\":{\"id\":{\"type\":\"INT64\",\"isOptional\":false}}}",
     "value.schema": "{\"name\":\"com.example.users.User\",\"type\":\"STRUCT\",\"isOptional\":false,\"fieldSchemas\":{\"id\":{\"type\":\"INT64\",\"isOptional\":false},\"first_name\":{\"type\":\"STRING\",\"isOptional\":true},\"last_name\":{\"type\":\"STRING\",\"isOptional\":true},\"email\":{\"type\":\"STRING\",\"isOptional\":true},\"gender\":{\"type\":\"STRING\",\"isOptional\":true},\"ip_address\":{\"type\":\"STRING\",\"isOptional\":true},\"last_login\":{\"name\":\"org.apache.kafka.connect.data.Timestamp\",\"type\":\"INT64\",\"version\":1,\"isOptional\":true},\"account_balance\":{\"name\":\"org.apache.kafka.connect.data.Decimal\",\"type\":\"BYTES\",\"version\":1,\"parameters\":{\"scale\":\"2\"},\"isOptional\":true},\"country\":{\"type\":\"STRING\",\"isOptional\":true},\"favorite_color\":{\"type\":\"STRING\",\"isOptional\":true}}}",
     "input.path.walk.recursively": "true",
-    "input.path.walk.recursively.retain.sub.dirs": "false"
+    "cleanup.policy.maintain.relative.path": "false"
   }
 }

--- a/config/CSVExample-subdir-walk.json
+++ b/config/CSVExample-subdir-walk.json
@@ -1,0 +1,19 @@
+{
+  "name": "CsvSpoolDir",
+  "config": {
+    "tasks.max": "1",
+    "connector.class": "com.github.jcustenborder.kafka.connect.spooldir.SpoolDirCsvSourceConnector",
+    "input.file.pattern": "^.*\\.csv$",
+    "halt.on.error": "false",
+    "topic": "testing",
+    "csv.first.row.as.header": "true",
+    "csv.null.field.indicator": "EMPTY_SEPARATORS",
+    "input.path": "/tmp/spooldir/input",
+    "finished.path": "/tmp/spooldir/finished",
+    "error.path": "/tmp/spooldir/error",
+    "key.schema": "{\"name\":\"com.example.users.UserKey\",\"type\":\"STRUCT\",\"isOptional\":false,\"fieldSchemas\":{\"id\":{\"type\":\"INT64\",\"isOptional\":false}}}",
+    "value.schema": "{\"name\":\"com.example.users.User\",\"type\":\"STRUCT\",\"isOptional\":false,\"fieldSchemas\":{\"id\":{\"type\":\"INT64\",\"isOptional\":false},\"first_name\":{\"type\":\"STRING\",\"isOptional\":true},\"last_name\":{\"type\":\"STRING\",\"isOptional\":true},\"email\":{\"type\":\"STRING\",\"isOptional\":true},\"gender\":{\"type\":\"STRING\",\"isOptional\":true},\"ip_address\":{\"type\":\"STRING\",\"isOptional\":true},\"last_login\":{\"name\":\"org.apache.kafka.connect.data.Timestamp\",\"type\":\"INT64\",\"version\":1,\"isOptional\":true},\"account_balance\":{\"name\":\"org.apache.kafka.connect.data.Decimal\",\"type\":\"BYTES\",\"version\":1,\"parameters\":{\"scale\":\"2\"},\"isOptional\":true},\"country\":{\"type\":\"STRING\",\"isOptional\":true},\"favorite_color\":{\"type\":\"STRING\",\"isOptional\":true}}}",
+    "input.path.walk.recursively": "true",
+    "input.path.walk.recursively.retain.sub.dirs": "false"
+  }
+}

--- a/config/CSVExample-subdir-walk.properties
+++ b/config/CSVExample-subdir-walk.properties
@@ -1,0 +1,43 @@
+#
+# Copyright © 2016 Jeremy Custenborder (jcustenborder@gmail.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name=CsvSpoolDir
+tasks.max=1
+connector.class=com.github.jcustenborder.kafka.connect.spooldir.SpoolDirCsvSourceConnector
+input.file.pattern=^.*\.csv$
+
+halt.on.error=false
+topic=testing
+key.schema={"name":"com.example.users.UserKey","type":"STRUCT","isOptional":false,"fieldSchemas":{"id":{"type":"INT64","isOptional":false}}}
+value.schema={"name":"com.example.users.User","type":"STRUCT","isOptional":false,"fieldSchemas":{"id":{"type":"INT64","isOptional":false},"first_name":{"type":"STRING","isOptional":true},"last_name":{"type":"STRING","isOptional":true},"email":{"type":"STRING","isOptional":true},"gender":{"type":"STRING","isOptional":true},"ip_address":{"type":"STRING","isOptional":true},"last_login":{"name":"org.apache.kafka.connect.data.Timestamp","type":"INT64","version":1,"isOptional":true},"account_balance":{"name":"org.apache.kafka.connect.data.Decimal","type":"BYTES","version":1,"parameters":{"scale":"2"},"isOptional":true},"country":{"type":"STRING","isOptional":true},"favorite_color":{"type":"STRING","isOptional":true}}}
+csv.first.row.as.header=true
+csv.null.field.indicator=EMPTY_SEPARATORS
+
+input.path=/tmp/spooldir/input
+finished.path=/tmp/spooldir/finished
+error.path=/tmp/spooldir/error
+batch.size = 5000
+cleanup.policy = DELETE
+file.buffer.size.bytes = 1048576
+
+input.path.walk.recursively = true
+input.path.walk.recursively.retain.sub.dirs = false
+
+# if using https://github.com/jcustenborder/kafka-connect-transform-common
+# you can capture the sub-dir the file was spooled out of
+#transforms = captureSubDir
+#transforms.captureSubDir.type = com.github.jcustenborder.kafka.connect.transform.common.HeaderToField$Value
+#transforms.captureSubDir.header.mappings = file.input.path.sub.dir.path:STRING:data_subdir

--- a/config/CSVExample-subdir-walk.properties
+++ b/config/CSVExample-subdir-walk.properties
@@ -34,10 +34,10 @@ cleanup.policy = DELETE
 file.buffer.size.bytes = 1048576
 
 input.path.walk.recursively = true
-input.path.walk.recursively.retain.sub.dirs = false
+cleanup.policy.maintain.relative.path = false
 
 # if using https://github.com/jcustenborder/kafka-connect-transform-common
 # you can capture the sub-dir the file was spooled out of
 #transforms = captureSubDir
 #transforms.captureSubDir.type = com.github.jcustenborder.kafka.connect.transform.common.HeaderToField$Value
-#transforms.captureSubDir.header.mappings = file.input.path.sub.dir.path:STRING:data_subdir
+#transforms.captureSubDir.header.mappings = file.relative.path:STRING:data_subdir

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
@@ -41,11 +41,13 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   public static final String FILE_SORT_ATTRIBUTES_CONF = "files.sort.attributes";
 
   public static final String INPUT_PATH_WALK_RECURSIVELY = "input.path.walk.recursively";
-  static final String INPUT_PATH_WALK_RECURSIVELY_DOC = "If enabled, activates a recursive walk of sub-directories under input.path searching for files matching input.file.pattern";
-  
-  public static final String INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS = "input.path.walk.recursively.retain.sub.dirs";
-  static final String INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS_DOC = "When input.path.walk.recursively is enabled, if discovered sub dirs under input.path will be retained regardless of success/failure of file processing";
-  
+  public static final boolean INPUT_PATH_WALK_RECURSIVELY_DEFAULT = false;
+  static final String INPUT_PATH_WALK_RECURSIVELY_DOC = "If enabled, any sub-directories dropped under `input.path` will be recursively walked looking for files matching the configured `input.file.pattern`. After processing is complete the discovered sub directory structure (as well as files within them) will handled according to the configured `cleanup.policy` (i.e. moved or deleted etc). For each discovered file, the walked sub-directory path will be set as a header named `file.relative.path`";
+
+  public static final String CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH = "cleanup.policy.maintain.relative.path";
+  static final boolean CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH_DEFAULT = false;
+  static final String CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH_DOC = "If `input.path.walk.recursively` is enabled in combination with this flag being `true`, the walked sub-directories which contained files will be retained as-is under the `input.path`. The actual files within the sub-directories will moved (with a copy of the sub-dir structure) or deleted as per the `cleanup.policy` defined, but the parent sub-directory structure will remain.";
+
   public static final String PROCESSING_FILE_EXTENSION_CONF = "processing.file.extension";
   //RecordProcessorConfig
   public static final String BATCH_SIZE_CONF = "batch.size";
@@ -175,7 +177,7 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
     this.taskCount = getInt(TASK_COUNT_CONF);
     this.taskPartitioner = ConfigUtils.getEnum(TaskPartitioner.class, this, TASK_PARTITIONER_CONF);
     this.inputPathWalkRecursively = this.getBoolean(INPUT_PATH_WALK_RECURSIVELY);
-    this.inputPathWalkRecursivelyRetainSubDirs = this.getBoolean(INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS);
+    this.inputPathWalkRecursivelyRetainSubDirs = this.getBoolean(CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH);
 
     if (bufferedInputStream) {
       this.fileBufferSizeBytes = getInt(FILE_BUFFER_SIZE_CONF);
@@ -316,14 +318,14 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
             ConfigKeyBuilder.of(INPUT_PATH_WALK_RECURSIVELY, ConfigDef.Type.BOOLEAN)
                 .documentation(INPUT_PATH_WALK_RECURSIVELY_DOC)
                 .importance(ConfigDef.Importance.LOW)
-                .defaultValue(false)
+                .defaultValue(INPUT_PATH_WALK_RECURSIVELY_DEFAULT)
                 .group(GROUP_FILESYSTEM)
                 .build()
         ).define(
-            ConfigKeyBuilder.of(INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, ConfigDef.Type.BOOLEAN)
-                .documentation(INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS_DOC)
+            ConfigKeyBuilder.of(CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH, ConfigDef.Type.BOOLEAN)
+                .documentation(CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH_DOC)
                 .importance(ConfigDef.Importance.LOW)
-                .defaultValue(false)
+                .defaultValue(CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH_DEFAULT)
                 .group(GROUP_FILESYSTEM)
                 .build()
         );

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
@@ -39,6 +39,7 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   public static final String HALT_ON_ERROR_CONF = "halt.on.error";
   public static final String FILE_MINIMUM_AGE_MS_CONF = "file.minimum.age.ms";
   public static final String FILE_SORT_ATTRIBUTES_CONF = "files.sort.attributes";
+  public static final String FILE_WALK_RECURSIVELY = "files.walk.recursively";
 
   public static final String PROCESSING_FILE_EXTENSION_CONF = "processing.file.extension";
   //RecordProcessorConfig
@@ -103,6 +104,9 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   static final String FILE_BUFFER_SIZE_DOC = "The size of buffer for the BufferedInputStream that will be used to " +
       "interact with the file system.";
 
+  static final String FILE_WALK_RECURSIVELY_DOC = "If enabled, activates a recursive walk of sub-directories under input.path searching for files matching input.file.pattern";
+  
+
   public final File inputPath;
   public final File finishedPath;
   public final File errorPath;
@@ -121,6 +125,7 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   public final TaskPartitioner taskPartitioner;
   public final boolean bufferedInputStream;
   public final int fileBufferSizeBytes;
+  public final boolean filesWalkRecursively;
 
   public final boolean finishedPathRequired() {
     boolean result;
@@ -165,6 +170,7 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
     this.taskIndex = getInt(TASK_INDEX_CONF);
     this.taskCount = getInt(TASK_COUNT_CONF);
     this.taskPartitioner = ConfigUtils.getEnum(TaskPartitioner.class, this, TASK_PARTITIONER_CONF);
+    this.filesWalkRecursively = this.getBoolean(FILE_WALK_RECURSIVELY);
 
     if (bufferedInputStream) {
       this.fileBufferSizeBytes = getInt(FILE_BUFFER_SIZE_CONF);
@@ -301,6 +307,13 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
                 .defaultValue(TaskPartitioner.ByName.toString())
                 .group(GROUP_FILESYSTEM)
                 .build()
+        ).define(
+          ConfigKeyBuilder.of(FILE_WALK_RECURSIVELY, ConfigDef.Type.BOOLEAN)
+          .documentation(FILE_WALK_RECURSIVELY_DOC)
+          .importance(ConfigDef.Importance.LOW)
+          .defaultValue(false)
+          .group(GROUP_FILESYSTEM)
+          .build()
         );
 
     if (bufferedInputStream) {

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceConnectorConfig.java
@@ -39,8 +39,13 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   public static final String HALT_ON_ERROR_CONF = "halt.on.error";
   public static final String FILE_MINIMUM_AGE_MS_CONF = "file.minimum.age.ms";
   public static final String FILE_SORT_ATTRIBUTES_CONF = "files.sort.attributes";
-  public static final String FILE_WALK_RECURSIVELY = "files.walk.recursively";
 
+  public static final String INPUT_PATH_WALK_RECURSIVELY = "input.path.walk.recursively";
+  static final String INPUT_PATH_WALK_RECURSIVELY_DOC = "If enabled, activates a recursive walk of sub-directories under input.path searching for files matching input.file.pattern";
+  
+  public static final String INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS = "input.path.walk.recursively.retain.sub.dirs";
+  static final String INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS_DOC = "When input.path.walk.recursively is enabled, if discovered sub dirs under input.path will be retained regardless of success/failure of file processing";
+  
   public static final String PROCESSING_FILE_EXTENSION_CONF = "processing.file.extension";
   //RecordProcessorConfig
   public static final String BATCH_SIZE_CONF = "batch.size";
@@ -104,8 +109,6 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   static final String FILE_BUFFER_SIZE_DOC = "The size of buffer for the BufferedInputStream that will be used to " +
       "interact with the file system.";
 
-  static final String FILE_WALK_RECURSIVELY_DOC = "If enabled, activates a recursive walk of sub-directories under input.path searching for files matching input.file.pattern";
-  
 
   public final File inputPath;
   public final File finishedPath;
@@ -125,7 +128,8 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
   public final TaskPartitioner taskPartitioner;
   public final boolean bufferedInputStream;
   public final int fileBufferSizeBytes;
-  public final boolean filesWalkRecursively;
+  public final boolean inputPathWalkRecursively;
+  public final boolean inputPathWalkRecursivelyRetainSubDirs;
 
   public final boolean finishedPathRequired() {
     boolean result;
@@ -170,7 +174,8 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
     this.taskIndex = getInt(TASK_INDEX_CONF);
     this.taskCount = getInt(TASK_COUNT_CONF);
     this.taskPartitioner = ConfigUtils.getEnum(TaskPartitioner.class, this, TASK_PARTITIONER_CONF);
-    this.filesWalkRecursively = this.getBoolean(FILE_WALK_RECURSIVELY);
+    this.inputPathWalkRecursively = this.getBoolean(INPUT_PATH_WALK_RECURSIVELY);
+    this.inputPathWalkRecursivelyRetainSubDirs = this.getBoolean(INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS);
 
     if (bufferedInputStream) {
       this.fileBufferSizeBytes = getInt(FILE_BUFFER_SIZE_CONF);
@@ -308,12 +313,19 @@ public abstract class AbstractSourceConnectorConfig extends AbstractConfig {
                 .group(GROUP_FILESYSTEM)
                 .build()
         ).define(
-          ConfigKeyBuilder.of(FILE_WALK_RECURSIVELY, ConfigDef.Type.BOOLEAN)
-          .documentation(FILE_WALK_RECURSIVELY_DOC)
-          .importance(ConfigDef.Importance.LOW)
-          .defaultValue(false)
-          .group(GROUP_FILESYSTEM)
-          .build()
+            ConfigKeyBuilder.of(INPUT_PATH_WALK_RECURSIVELY, ConfigDef.Type.BOOLEAN)
+                .documentation(INPUT_PATH_WALK_RECURSIVELY_DOC)
+                .importance(ConfigDef.Importance.LOW)
+                .defaultValue(false)
+                .group(GROUP_FILESYSTEM)
+                .build()
+        ).define(
+            ConfigKeyBuilder.of(INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, ConfigDef.Type.BOOLEAN)
+                .documentation(INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS_DOC)
+                .importance(ConfigDef.Importance.LOW)
+                .defaultValue(false)
+                .group(GROUP_FILESYSTEM)
+                .build()
         );
 
     if (bufferedInputStream) {

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFile.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFile.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -75,6 +76,16 @@ public class InputFile implements Closeable {
       "lz4", CompressorStreamFactory.LZ4_BLOCK,
       "z", CompressorStreamFactory.Z
   );
+
+
+  static String determineInputPathSubDir(File inputPath, File inputFile) {
+    Path relative = inputPath.toPath().relativize(inputFile.getParentFile().toPath());
+    String subDir = relative.toString();
+    if ("".equals(subDir)) {
+      return null;
+    } 
+    return subDir;
+  }
 
   public String inputPathSubDir() {
     return this.inputPathSubDir;
@@ -251,7 +262,9 @@ public class InputFile implements Closeable {
 
     if (this.inputPathSubDir != null) {
       outputDirectory = new File(outputDirectory, this.inputPathSubDir);
-      outputDirectory.mkdirs();
+      if (!outputDirectory.isDirectory()) {
+        outputDirectory.mkdirs();
+      }
     }
 
     File outputFile = new File(outputDirectory, this.file.getName());

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFileDequeue.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFileDequeue.java
@@ -59,6 +59,15 @@ public class InputFileDequeue extends ForwardingDeque<InputFile> {
     return new File(input.getParentFile(), fileName);
   }
 
+  static String determineInputPathSubDir(File inputPath, File inputFile) {
+    String subDir = inputFile.getParentFile().getAbsolutePath().replaceAll(inputPath.getAbsolutePath(), "");
+    if ("".equals(subDir)) {
+      return null;
+    } else {
+      return subDir.substring(1, subDir.length());
+    }
+  }
+
   @Override
   protected Deque<InputFile> delegate() {
     if (null != files && !files.isEmpty()) {
@@ -69,7 +78,7 @@ public class InputFileDequeue extends ForwardingDeque<InputFile> {
 
     File[] input = null;
 
-    if (this.config.filesWalkRecursively) {
+    if (this.config.inputPathWalkRecursively) {
 
       final PatternFilenameFilter walkerFilenameFilter = this.config.inputFilenameFilter;
       Predicate<Path> filenameFilterPredicate = new Predicate<Path>() {
@@ -110,7 +119,7 @@ public class InputFileDequeue extends ForwardingDeque<InputFile> {
         .filter(this.processingFileExists)
         .filter(this.fileMinimumAge)
         .sorted(this.fileComparator)
-        .map(f -> new InputFile(this.config, f))
+        .map(f -> new InputFile(this.config, f, determineInputPathSubDir(this.config.inputPath, f)))
         .collect(Collectors.toCollection(ArrayDeque::new));
     return this.files;
   }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFileDequeue.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFileDequeue.java
@@ -59,15 +59,6 @@ public class InputFileDequeue extends ForwardingDeque<InputFile> {
     return new File(input.getParentFile(), fileName);
   }
 
-  static String determineInputPathSubDir(File inputPath, File inputFile) {
-    String subDir = inputFile.getParentFile().getAbsolutePath().replaceAll(inputPath.getAbsolutePath(), "");
-    if ("".equals(subDir)) {
-      return null;
-    } else {
-      return subDir.substring(1, subDir.length());
-    }
-  }
-
   @Override
   protected Deque<InputFile> delegate() {
     if (null != files && !files.isEmpty()) {
@@ -119,7 +110,7 @@ public class InputFileDequeue extends ForwardingDeque<InputFile> {
         .filter(this.processingFileExists)
         .filter(this.fileMinimumAge)
         .sorted(this.fileComparator)
-        .map(f -> new InputFile(this.config, f, determineInputPathSubDir(this.config.inputPath, f)))
+        .map(f -> new InputFile(this.config, f, InputFile.determineInputPathSubDir(this.config.inputPath, f)))
         .collect(Collectors.toCollection(ArrayDeque::new));
     return this.files;
   }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/Metadata.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/Metadata.java
@@ -36,13 +36,16 @@ class Metadata {
   static final String HEADER_LAST_MODIFIED = "file.last.modified";
   static final String HEADER_LENGTH = "file.length";
   static final String HEADER_OFFSET = "file.offset";
+  static final String HEADER_INPUT_PATH_SUB_DIR_PATH = "file.input.path.sub.dir.path";
 
   final String path;
   final String name;
   final String nameWithoutExtension;
   final Date lastModified;
   final long length;
+  final String inputPathSubDirPath;
   String parentDirName = null;
+
 
   public static final Map<String, String> HEADER_DESCRIPTIONS;
 
@@ -55,6 +58,7 @@ class Metadata {
     result.put(HEADER_LAST_MODIFIED, "The last modified date of the file.");
     result.put(HEADER_LENGTH, "The size of the file in bytes.");
     result.put(HEADER_OFFSET, "The offset for this piece of data within the file.");
+    result.put(HEADER_INPUT_PATH_SUB_DIR_PATH, "The file's parent sub-directory relative from the input.path.");
     HEADER_DESCRIPTIONS = ImmutableMap.copyOf(result);
   }
 
@@ -75,7 +79,7 @@ class Metadata {
 
 
 
-  public Metadata(File file) {
+  public Metadata(File file, String inputPathSubDirPath) {
     this.path = file.getAbsolutePath();
     this.name = file.getName();
     this.lastModified = new Date(file.lastModified());
@@ -85,6 +89,8 @@ class Metadata {
     if (file.getParentFile() != null) {
       this.parentDirName = file.getParentFile().getName();
     }
+    
+    this.inputPathSubDirPath = inputPathSubDirPath;
   }
 
   /**
@@ -101,6 +107,11 @@ class Metadata {
     headers.addLong(HEADER_LENGTH, this.length);
     headers.addLong(HEADER_OFFSET, offset);
     headers.addTimestamp(HEADER_LAST_MODIFIED, this.lastModified);
+
+    if (this.inputPathSubDirPath != null) {
+      headers.addString(HEADER_INPUT_PATH_SUB_DIR_PATH, this.inputPathSubDirPath);
+    }
+
     return headers;
   }
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/Metadata.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/Metadata.java
@@ -36,7 +36,7 @@ class Metadata {
   static final String HEADER_LAST_MODIFIED = "file.last.modified";
   static final String HEADER_LENGTH = "file.length";
   static final String HEADER_OFFSET = "file.offset";
-  static final String HEADER_INPUT_PATH_SUB_DIR_PATH = "file.input.path.sub.dir.path";
+  static final String HEADER_FILE_RELATIVE_PATH = "file.relative.path";
 
   final String path;
   final String name;
@@ -58,7 +58,7 @@ class Metadata {
     result.put(HEADER_LAST_MODIFIED, "The last modified date of the file.");
     result.put(HEADER_LENGTH, "The size of the file in bytes.");
     result.put(HEADER_OFFSET, "The offset for this piece of data within the file.");
-    result.put(HEADER_INPUT_PATH_SUB_DIR_PATH, "The file's parent sub-directory relative from the input.path.");
+    result.put(HEADER_FILE_RELATIVE_PATH, "The file's parent sub-directory relative from the input.path.");
     HEADER_DESCRIPTIONS = ImmutableMap.copyOf(result);
   }
 
@@ -109,7 +109,7 @@ class Metadata {
     headers.addTimestamp(HEADER_LAST_MODIFIED, this.lastModified);
 
     if (this.inputPathSubDirPath != null) {
-      headers.addString(HEADER_INPUT_PATH_SUB_DIR_PATH, this.inputPathSubDirPath);
+      headers.addString(HEADER_FILE_RELATIVE_PATH, this.inputPathSubDirPath);
     }
 
     return headers;

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractCleanUpPolicyTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractCleanUpPolicyTest.java
@@ -24,34 +24,53 @@ public abstract class AbstractCleanUpPolicyTest<T extends AbstractCleanUpPolicy>
   File inputPath;
   File finishedPath;
   File errorPath;
+  String inputPathSubDir;
   protected T cleanupPolicy;
 
   protected abstract T create(
       InputFile inputFile, File errorPath, File finishedPath
   );
 
+  protected String defineInputPathSubDir() {
+    return null;
+  }
+
+  protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
+    return new ImmutableMap.Builder<String,String>()
+      .put(SpoolDirBinaryFileSourceConnectorConfig.TOPIC_CONF, "foo")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_CONFIG, this.inputPath.toString())
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_FILE_PATTERN_CONF, "^.$")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.ERROR_PATH_CONFIG, this.errorPath.toString())
+      .put(SpoolDirBinaryFileSourceConnectorConfig.FINISHED_PATH_CONFIG, this.finishedPath.toString());
+  }
+
   @BeforeEach
   public void before() throws IOException {
     this.errorPath = Files.createTempDir();
     this.finishedPath = Files.createTempDir();
     this.inputPath = Files.createTempDir();
+    this.inputPathSubDir = defineInputPathSubDir();
 
-    File inputFile = File.createTempFile("input", "file", this.inputPath);
+    File tempFileParentPathDir = this.inputPath;
+    if (this.inputPathSubDir != null) {
+      tempFileParentPathDir = new File(this.inputPath, this.inputPathSubDir);
+      tempFileParentPathDir.mkdirs();
+    }
 
-    SpoolDirBinaryFileSourceConnectorConfig config = new SpoolDirBinaryFileSourceConnectorConfig(
-        ImmutableMap.of(
-            SpoolDirBinaryFileSourceConnectorConfig.TOPIC_CONF, "foo",
-            SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_CONFIG, this.inputPath.toString(),
-            SpoolDirBinaryFileSourceConnectorConfig.INPUT_FILE_PATTERN_CONF, "^.$",
-            SpoolDirBinaryFileSourceConnectorConfig.ERROR_PATH_CONFIG, this.errorPath.toString(),
-            SpoolDirBinaryFileSourceConnectorConfig.FINISHED_PATH_CONFIG, this.finishedPath.toString()
-        )
-    );
+    File inputFile = File.createTempFile("input", "file", tempFileParentPathDir);
 
-    this.inputFile = new InputFile(config, inputFile);
+    SpoolDirBinaryFileSourceConnectorConfig config = 
+      new SpoolDirBinaryFileSourceConnectorConfig(getConnectorConfigMap().build());
+
+    this.inputFile = new InputFile(config, inputFile, this.inputPathSubDir);
     this.inputFile.inputStreamReader = mock(InputStreamReader.class);
     this.inputFile.lineNumberReader = mock(LineNumberReader.class);
     this.cleanupPolicy = create(this.inputFile, this.errorPath, this.finishedPath);
+  }
+
+  protected File getTargetFilePath(File containerPath, InputFile inputFile) {
+    String subDir = (this.defineInputPathSubDir() != null ? this.defineInputPathSubDir() : "");
+    return new File(new File(containerPath,subDir), inputFile.getName());
   }
 
   @Test
@@ -59,7 +78,7 @@ public abstract class AbstractCleanUpPolicyTest<T extends AbstractCleanUpPolicy>
     assertTrue(this.inputFile.exists(), "Input file should exist");
     this.cleanupPolicy.error();
     assertFalse(this.inputFile.exists(), "input file should not exist");
-    File erroredFile = new File(this.errorPath, this.inputFile.getName());
+    File erroredFile = this.getTargetFilePath(this.errorPath,this.inputFile);
     assertTrue(erroredFile.exists(), "errored file should exist.");
   }
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSpoolDirSourceTaskTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSpoolDirSourceTaskTest.java
@@ -167,7 +167,7 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
     headersToRemove.add(Metadata.HEADER_PARENT_DIR_NAME);
     
     if (this.defineInputPathSubDir() != null) {
-      headersToRemove.add(Metadata.HEADER_INPUT_PATH_SUB_DIR_PATH);
+      headersToRemove.add(Metadata.HEADER_FILE_RELATIVE_PATH);
     }
 
     for (int i = 0; i < testCase.expected.size(); i++) {

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSpoolDirSourceTaskTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSpoolDirSourceTaskTest.java
@@ -34,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,17 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
     return settings;
   }
 
+  protected String defineInputPathSubDir() {
+    return null;
+  }
+
+  protected File getTargetFilePath(File containerPath, String inputFileName) {
+    String subDir = (this.defineInputPathSubDir() != null ? this.defineInputPathSubDir() : "");
+    File targetDir = new File(containerPath,subDir);
+    targetDir.mkdirs();
+    return new File(targetDir, inputFileName);
+  }
+
   protected void poll(final String packageName, TestCase testCase) throws InterruptedException, IOException {
     String keySchemaConfig = ObjectMapperFactory.INSTANCE.writeValueAsString(testCase.keySchema);
     String valueSchemaConfig = ObjectMapperFactory.INSTANCE.writeValueAsString(testCase.valueSchema);
@@ -118,8 +130,8 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
 
     //Use this config because it's the simplest.
     SpoolDirBinaryFileSourceConnectorConfig config = new SpoolDirBinaryFileSourceConnectorConfig(settings);
-
-    final File p = new File(this.inputPath, inputFileName);
+    
+    final File p = this.getTargetFilePath(this.inputPath, inputFileName);
     try (InputStream inputStream = this.getClass().getResourceAsStream(dataFile)) {
       assertNotNull(
           inputStream,
@@ -130,7 +142,7 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
       }
     }
 
-    final InputFile inputFile = new InputFile(config, p);
+    final InputFile inputFile = new InputFile(config, p, this.defineInputPathSubDir());
     log.trace("poll(String, TestCase) - inputFile = {}", inputFile);
 
     assertFalse(inputFile.processingFlag().exists(), String.format("processingFile %s should not exist before first poll().", inputFile.processingFlag()));
@@ -147,13 +159,16 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
     The following headers will change. Lets ensure they are there but we don't care about their
     values since they are driven by things that will change such as lastModified dates and paths.
      */
-    List<String> headersToRemove = Arrays.asList(
-        Metadata.HEADER_LAST_MODIFIED,
-        Metadata.HEADER_PATH,
-        Metadata.HEADER_LENGTH,
-        Metadata.HEADER_NAME_WITHOUT_EXTENSION,
-        Metadata.HEADER_PARENT_DIR_NAME
-    );
+    List<String> headersToRemove = new ArrayList<String>();
+    headersToRemove.add(Metadata.HEADER_LAST_MODIFIED);
+    headersToRemove.add(Metadata.HEADER_PATH);
+    headersToRemove.add(Metadata.HEADER_LENGTH);
+    headersToRemove.add(Metadata.HEADER_NAME_WITHOUT_EXTENSION);
+    headersToRemove.add(Metadata.HEADER_PARENT_DIR_NAME);
+    
+    if (this.defineInputPathSubDir() != null) {
+      headersToRemove.add(Metadata.HEADER_INPUT_PATH_SUB_DIR_PATH);
+    }
 
     for (int i = 0; i < testCase.expected.size(); i++) {
       SourceRecord expectedRecord = testCase.expected.get(i);
@@ -176,7 +191,7 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
     assertNull(records, "records should be null after first poll.");
     assertFalse(inputFile.exists(), String.format("inputFile %s should not exist.", inputFile));
     assertFalse(inputFile.processingFlag().exists(), String.format("processingFile %s should not exist.", inputFile.processingFlag()));
-    final File finishedFile = new File(this.finishedPath, inputFileName);
+    final File finishedFile = this.getTargetFilePath(this.finishedPath, inputFileName);
     assertTrue(finishedFile.exists(), String.format("finishedFile %s should exist.", finishedFile));
   }
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsNoRetainTest.java
@@ -18,7 +18,7 @@ public class DeleteCleanupPolicySubDirsNoRetainTest extends DeleteCleanupPolicyT
   protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
     return super.getConnectorConfigMap()
       .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
-      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "false");
+      .put(SpoolDirBinaryFileSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH, "false");
   }
 
   @Test

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsNoRetainTest.java
@@ -1,0 +1,31 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class DeleteCleanupPolicySubDirsNoRetainTest extends DeleteCleanupPolicyTest {
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+  protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
+    return super.getConnectorConfigMap()
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "false");
+  }
+
+  @Test
+  public void success() throws IOException {
+    super.success();
+
+    assertFalse(new File(this.inputPath,this.defineInputPathSubDir()).exists(), 
+      "The input.path sub-directory "+this.defineInputPathSubDir()+" should not exist");
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsRetainTest.java
@@ -18,7 +18,7 @@ public class DeleteCleanupPolicySubDirsRetainTest extends DeleteCleanupPolicyTes
   protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
     return super.getConnectorConfigMap()
       .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
-      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "true");
+      .put(SpoolDirBinaryFileSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH, "true");
   }
 
   @Test

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/DeleteCleanupPolicySubDirsRetainTest.java
@@ -1,0 +1,31 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DeleteCleanupPolicySubDirsRetainTest extends DeleteCleanupPolicyTest {
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+  protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
+    return super.getConnectorConfigMap()
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "true");
+  }
+
+  @Test
+  public void success() throws IOException {
+    super.success();
+
+    assertTrue(new File(this.inputPath,this.defineInputPathSubDir()).exists(), 
+      "The input.path sub-directory "+this.defineInputPathSubDir()+" should exist");
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsNoRetainTest.java
@@ -18,7 +18,7 @@ public class MoveByDateCleanupPolicySubDirsNoRetainTest extends MoveByDateCleanu
   protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
     return super.getConnectorConfigMap()
       .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
-      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "false");
+      .put(SpoolDirBinaryFileSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH, "false");
   }
 
   @Test

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsNoRetainTest.java
@@ -1,0 +1,32 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class MoveByDateCleanupPolicySubDirsNoRetainTest extends MoveByDateCleanupPolicyTest {
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+  protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
+    return super.getConnectorConfigMap()
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "false");
+  }
+
+  @Test
+  public void success() throws IOException {
+    super.success();
+
+    assertFalse(new File(this.inputPath,this.defineInputPathSubDir()).exists(), 
+      "The input.path sub-directory "+this.defineInputPathSubDir()+" should not exist");
+
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsRetainTest.java
@@ -17,7 +17,7 @@ public class MoveByDateCleanupPolicySubDirsRetainTest extends MoveByDateCleanupP
   protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
     return super.getConnectorConfigMap()
       .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
-      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "true");
+      .put(SpoolDirBinaryFileSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH, "true");
   }
 
   @Test

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicySubDirsRetainTest.java
@@ -1,0 +1,31 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MoveByDateCleanupPolicySubDirsRetainTest extends MoveByDateCleanupPolicyTest {
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+  protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
+    return super.getConnectorConfigMap()
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "true");
+  }
+
+  @Test
+  public void success() throws IOException {
+    super.success();
+
+    assertTrue(new File(this.inputPath,this.defineInputPathSubDir()).exists(), 
+      "The input.path sub-directory "+this.defineInputPathSubDir()+" should exist");
+
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicyTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveByDateCleanupPolicyTest.java
@@ -21,7 +21,7 @@ public class MoveByDateCleanupPolicyTest extends AbstractCleanUpPolicyTest<Abstr
   public void success() throws IOException {
     SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
     Path subDirectory = Paths.get(this.finishedPath.getAbsolutePath(), dateFormatter.format(this.inputFile.lastModified()));
-    File finishedFile = new File(subDirectory.toFile(), this.inputFile.getName());
+    File finishedFile = this.getTargetFilePath(subDirectory.toFile(), this.inputFile);
 
     assertTrue(this.inputFile.exists(), "Input file should exist");
     assertFalse(finishedFile.exists(), "Finished file should not exist");

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsNoRetainTest.java
@@ -19,7 +19,7 @@ public class MoveCleanupPolicySubDirsNoRetainTest extends MoveCleanupPolicyTest 
   protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
     return super.getConnectorConfigMap()
       .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
-      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "false");
+      .put(SpoolDirBinaryFileSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH, "false");
   }
 
   @Test

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsNoRetainTest.java
@@ -1,0 +1,33 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class MoveCleanupPolicySubDirsNoRetainTest extends MoveCleanupPolicyTest {
+
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+  protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
+    return super.getConnectorConfigMap()
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "false");
+  }
+
+  @Test
+  public void success() throws IOException {
+    super.success();
+
+    assertFalse(new File(this.inputPath,this.defineInputPathSubDir()).exists(), 
+      "The input.path sub-directory "+this.defineInputPathSubDir()+" should not exist");
+
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsRetainTest.java
@@ -1,0 +1,33 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MoveCleanupPolicySubDirsRetainTest extends MoveCleanupPolicyTest {
+
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+  protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
+    return super.getConnectorConfigMap()
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
+      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "true");
+  }
+
+  @Test
+  public void success() throws IOException {
+    super.success();
+
+    assertTrue(new File(this.inputPath,this.defineInputPathSubDir()).exists(), 
+      "The input.path sub-directory "+this.defineInputPathSubDir()+" should exist");
+
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicySubDirsRetainTest.java
@@ -19,7 +19,7 @@ public class MoveCleanupPolicySubDirsRetainTest extends MoveCleanupPolicyTest {
   protected ImmutableMap.Builder<String,String> getConnectorConfigMap() {
     return super.getConnectorConfigMap()
       .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY, "true")
-      .put(SpoolDirBinaryFileSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS, "true");
+      .put(SpoolDirBinaryFileSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH, "true");
   }
 
   @Test

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicyTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicyTest.java
@@ -16,7 +16,7 @@ public class MoveCleanupPolicyTest extends AbstractCleanUpPolicyTest<AbstractCle
 
   @Test
   public void success() throws IOException {
-    File finishedFile = new File(this.finishedPath, this.inputFile.getName());
+    File finishedFile = this.getTargetFilePath(this.finishedPath, this.inputFile);
     assertTrue(this.inputFile.exists(), "Input file should exist");
     assertFalse(finishedFile.exists(), "Finished file should not exist");
     this.cleanupPolicy.success();

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsNoRetainTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2016 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+public class SpoolDirCsvSourceTaskSubDirsNoRetainTest extends SpoolDirCsvSourceTaskTest {
+  private static final Logger log = LoggerFactory.getLogger(SpoolDirCsvSourceTaskSubDirsNoRetainTest.class);
+
+  @Override
+  protected Map<String, String> settings() {
+    Map<String, String> settings = super.settings();
+
+    settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY,"true");
+    settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS,"false");
+
+    return settings;
+  }
+
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsNoRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsNoRetainTest.java
@@ -27,7 +27,7 @@ public class SpoolDirCsvSourceTaskSubDirsNoRetainTest extends SpoolDirCsvSourceT
     Map<String, String> settings = super.settings();
 
     settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY,"true");
-    settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS,"false");
+    settings.put(AbstractSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH,"false");
 
     return settings;
   }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsRetainTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2016 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+public class SpoolDirCsvSourceTaskSubDirsRetainTest extends SpoolDirCsvSourceTaskTest {
+  private static final Logger log = LoggerFactory.getLogger(SpoolDirCsvSourceTaskSubDirsRetainTest.class);
+
+  @Override
+  protected Map<String, String> settings() {
+    Map<String, String> settings = super.settings();
+
+    settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY,"true");
+    settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS,"true");
+
+    return settings;
+  }
+
+  @Override
+  protected String defineInputPathSubDir() {
+    return "test/01/02/03";
+  }
+
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsRetainTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskSubDirsRetainTest.java
@@ -27,7 +27,7 @@ public class SpoolDirCsvSourceTaskSubDirsRetainTest extends SpoolDirCsvSourceTas
     Map<String, String> settings = super.settings();
 
     settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY,"true");
-    settings.put(AbstractSourceConnectorConfig.INPUT_PATH_WALK_RECURSIVELY_RETAIN_SUB_DIRS,"true");
+    settings.put(AbstractSourceConnectorConfig.CLEANUP_POLICY_MAINTAIN_RELATIVE_PATH,"true");
 
     return settings;
   }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskTest.java
@@ -112,8 +112,8 @@ public class SpoolDirCsvSourceTaskTest extends AbstractSpoolDirSourceTaskTest<Sp
               .put("id", i)
       );
     }
-
-    File inputFile = new File(this.inputPath, "input.csv");
+  
+    File inputFile = this.getTargetFilePath(this.inputPath,  "input.csv");
     writeCSV(inputFile, schema, values);
     Map<String, String> settings = settings();
     settings.put(SpoolDirCsvSourceConnectorConfig.KEY_SCHEMA_CONF, ObjectMapperFactory.INSTANCE.writeValueAsString(schema));


### PR DESCRIPTION
This is for what is discussed in #159, it also adds a new header `file.input.path.sub.dir.path` which contains the intermediate path under `input.path` that the file was located in. Added tests + README updates etc.