### PR TITLE
Fix handling input stream errors in SpoolDirLineDelimitedSourceTask

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
@@ -155,6 +155,7 @@ public abstract class AbstractSourceTask<CONF extends AbstractSourceConnectorCon
       }
       return null;
     }
+
     emptyCount = 0;
     log.trace("read() returning {} result(s)", results.size());
 
@@ -271,6 +272,9 @@ public abstract class AbstractSourceTask<CONF extends AbstractSourceConnectorCon
       if (this.config.haltOnError) {
         throw new ConnectException(ex);
       } else {
+        recordProcessingTime();
+        this.hasRecords = false;
+        this.inputFile = null;
         return new ArrayList<>();
       }
     }
@@ -278,14 +282,14 @@ public abstract class AbstractSourceTask<CONF extends AbstractSourceConnectorCon
 
   protected Map<String, ?> offset() {
     return ImmutableMap.of(
-        "offset",
-        recordOffset()
+            "offset",
+            recordOffset()
     );
   }
 
   protected SourceRecord record(
-      SchemaAndValue key,
-      SchemaAndValue value,
+          SchemaAndValue key,
+          SchemaAndValue value,
       Long timestamp) {
     Map<String, ?> sourceOffset = offset();
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirLineDelimitedSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirLineDelimitedSourceTask.java
@@ -43,15 +43,24 @@ public class SpoolDirLineDelimitedSourceTask extends AbstractSourceTask<SpoolDir
   protected List<SourceRecord> process() throws IOException {
     int recordCount = 0;
     List<SourceRecord> records = new ArrayList<>(this.config.batchSize);
-    String line = null;
-    while (recordCount < this.config.batchSize && null != (line = this.inputFile.lineNumberReader().readLine())) {
-      SourceRecord record = record(
-          null,
-          new SchemaAndValue(Schema.STRING_SCHEMA, line),
-          null
-      );
-      records.add(record);
-      recordCount++;
+    try {
+      String line = null;
+      while (recordCount < this.config.batchSize && null != (line = this.inputFile.lineNumberReader().readLine())) {
+        SourceRecord record = record(
+            null,
+            new SchemaAndValue(Schema.STRING_SCHEMA, line),
+            null
+        );
+        records.add(record);
+        recordCount++;
+        this.recordCount++;
+      }
+    } catch (IOException e) {
+      if (records.isEmpty()) {
+        // If no records where read, throw the exception to trigger error handling
+        // Otherwise, return the records and handle the error in the next iteration.
+        throw e;
+      }
     }
     return records;
   }


### PR DESCRIPTION
- Return records from current batch in case there is an error reading inputstream
- Record Processing stats and reset hasRecords in case there's an error during processing