### PR TITLE
closes issue #206

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFile.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFile.java
@@ -61,7 +61,7 @@ public class InputFile implements Closeable {
     this.length = this.file.length();
     String processingFileName = file.getName() + config.processingFileExtension;
     this.processingFlag = new File(file.getParentFile(), processingFileName);
-    this.inputPathSubDir = determineRelativePath(file, config.inputPath);
+    this.inputPathSubDir = determineRelativePath(config.inputPath, file);
     this.metadata = new Metadata(file, this.inputPathSubDir);
   }
 
@@ -75,7 +75,7 @@ public class InputFile implements Closeable {
 
 
   private static String determineRelativePath(File inputPath, File inputFile) {
-    Path relative = inputFile.toPath().relativize(inputPath.toPath()); // inputPath.toPath().relativize(inputFile.getParentFile().toPath());
+    Path relative = inputPath.toPath().relativize(inputFile.getParentFile().toPath());
     String subDir = relative.toString();
     if ("".equals(subDir)) {
       return null;

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSpoolDirSourceTaskTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSpoolDirSourceTaskTest.java
@@ -164,7 +164,6 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
     headersToRemove.add(Metadata.HEADER_LENGTH);
     headersToRemove.add(Metadata.HEADER_NAME_WITHOUT_EXTENSION);
     headersToRemove.add(Metadata.HEADER_PARENT_DIR_NAME);
-    headersToRemove.add(Metadata.HEADER_FILE_RELATIVE_PATH);
 
     for (int i = 0; i < testCase.expected.size(); i++) {
       SourceRecord expectedRecord = testCase.expected.get(i);
@@ -177,6 +176,17 @@ public abstract class AbstractSpoolDirSourceTaskTest<T extends AbstractSourceTas
         );
         actualRecord.headers().remove(headerToRemove);
         expectedRecord.headers().remove(headerToRemove);
+      }
+      /*
+      The file relative path header is created conditionally, so only remove it if expected to exist.
+       */
+      if (expectedRecord.headers().lastWithName(Metadata.HEADER_FILE_RELATIVE_PATH) != null) {
+        assertNotNull(
+          actualRecord.headers().lastWithName(Metadata.HEADER_FILE_RELATIVE_PATH),
+          String.format("index:%s should have the header '%s'", i, Metadata.HEADER_FILE_RELATIVE_PATH)
+        );
+        actualRecord.headers().remove(Metadata.HEADER_FILE_RELATIVE_PATH);
+        expectedRecord.headers().remove(Metadata.HEADER_FILE_RELATIVE_PATH);
       }
       assertSourceRecord(expectedRecord, actualRecord, String.format("index:%s", i));
     }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicyNoSubDirsTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/MoveCleanupPolicyNoSubDirsTest.java
@@ -1,0 +1,22 @@
+package com.github.jcustenborder.kafka.connect.spooldir;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+public class MoveCleanupPolicyNoSubDirsTest extends AbstractCleanUpPolicyTest<AbstractCleanUpPolicy.Move> {
+  @Override
+  protected AbstractCleanUpPolicy.Move create(InputFile inputFile, File errorPath, File finishedPath) {
+    return new AbstractCleanUpPolicy.Move(inputFile, errorPath, finishedPath);
+  }
+
+  @Test
+  public void inputFileNotTreatedAsSubdir() throws IOException {
+    assertNull(defineInputPathSubDir(), "Input path should not be a subdir");
+    assertNull(this.inputFile.inputPathSubDir(), "Input file should have no subdir");
+    this.inputFile.close();
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceTaskTest.java
@@ -72,6 +72,10 @@ public class SpoolDirCsvSourceTaskTest extends AbstractSpoolDirSourceTaskTest<Sp
 
     return testCases.stream().map(testCase -> {
       String name = Files.getNameWithoutExtension(testCase.path.toString());
+      if (defineInputPathSubDir() != null) {
+        String inputPathSubdir = defineInputPathSubDir();
+        testCase.expected.stream().forEach(record -> record.headers().addString(Metadata.HEADER_FILE_RELATIVE_PATH, inputPathSubdir));
+      }
       return dynamicTest(name, () -> {
         poll(packageName, testCase);
       });
@@ -112,7 +116,7 @@ public class SpoolDirCsvSourceTaskTest extends AbstractSpoolDirSourceTaskTest<Sp
               .put("id", i)
       );
     }
-  
+
     File inputFile = this.getTargetFilePath(this.inputPath,  "input.csv");
     writeCSV(inputFile, schema, values);
     Map<String, String> settings = settings();


### PR DESCRIPTION
Closes issue #206, Relative file path is not retrieved properly. Current state always identifies the filename as a subdir of input, and logs an error after failing to delete/move it.

The determineRelativePath() method was being called with the argument order reversed for the argument names, and needed to strip the filename off the path to get a match against the input directory when calling relativize().