### PR TITLE
Fix misleading messages logged by SpoolDirLineDelimitedSourceConnector

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/AbstractSourceTask.java
@@ -180,27 +180,27 @@ public abstract class AbstractSourceTask<CONF extends AbstractSourceConnectorCon
   }
 
   private void recordProcessingTime() {
-    final long secondsElapsed = processingTime.elapsed(TimeUnit.SECONDS);
-    final long bytesPerSecond;
+    final long elapsedMs = processingTime.elapsed(TimeUnit.MILLISECONDS);
+    final long bytesPerMs;
 
-    if (0L == secondsElapsed || 0L == this.inputFile.length()) {
-      bytesPerSecond = 0L;
+    if (0L == elapsedMs || 0L == this.inputFile.length()) {
+      bytesPerMs = 0L;
     } else {
-      bytesPerSecond = this.inputFile.length() / secondsElapsed;
+      bytesPerMs = this.inputFile.length() / elapsedMs;
     }
 
-    if (bytesPerSecond > 0) {
+    if (bytesPerMs > 0) {
       log.info(
-          "Finished processing {} record(s) in {} second(s). Processing speed {} per second.",
+          "Finished processing {} record(s) in {} millisecond(s). Processing speed {} per millisecond.",
           this.recordCount,
-          secondsElapsed,
-          humanReadableByteCount(bytesPerSecond, false)
+          elapsedMs,
+          humanReadableByteCount(bytesPerMs, false)
       );
     } else {
       log.info(
           "Finished processing {} record(s) in {} second(s).",
           this.recordCount,
-          secondsElapsed
+          elapsedMs
       );
     }
   }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFile.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/InputFile.java
@@ -223,7 +223,9 @@ public class InputFile implements Closeable {
       File lastSubDir = this.config.inputPath;
       for (String subDirName : this.inputPathSubDir.split(File.separator)) {
         lastSubDir = new File(lastSubDir, subDirName);
-        inputPathSubDirsToCleanup.add(lastSubDir);
+        if (lastSubDir.exists()) {
+          inputPathSubDirsToCleanup.add(lastSubDir);
+        }
       }
       Collections.reverse(inputPathSubDirsToCleanup);
     }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirLineDelimitedSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirLineDelimitedSourceTask.java
@@ -41,7 +41,6 @@ public class SpoolDirLineDelimitedSourceTask extends AbstractSourceTask<SpoolDir
 
   @Override
   protected List<SourceRecord> process() throws IOException {
-    int recordCount = 0;
     List<SourceRecord> records = new ArrayList<>(this.config.batchSize);
     String line = null;
     while (recordCount < this.config.batchSize && null != (line = this.inputFile.lineNumberReader().readLine())) {


### PR DESCRIPTION
https://github.com/jcustenborder/kafka-connect-spooldir/issues/213

Found two misleading logs while [testing SpoolDirLineDelimitedSourceConnector](https://github.com/vdesabou/kafka-docker-playground/blob/master/connect/connect-spool-dir-source/line-delimited.sh#L14) 

1. `Finished processing 0 record(s) in 0 second(s)` is logged even though connector is processing records
2. `Failed to delete input.path sub-directory: /tmp/data/input/fix.json ` is logged even though that file does not exist in the path as it has been moved after processing

## Fixes
1. Ensure SpoolDirLineDelimitedSourceTask updates recordCount in AbstractSourceTask and calculate processing speed in milliseconds (sometimes files are processed in less than a second, which leaves secondsElapsed set to 0)
2. `getInputPathSubDirsToCleanup()`  should only return dirs which exist
 